### PR TITLE
treewide: Rename the repo

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -18,7 +18,7 @@ jobs:
         with:
           # list of Docker images to use as base name for tags
           images: |
-            kalbasit/signal-receiver
+            kalbasit/signal-api-receiver
           # generate Docker tags based on the following events/attributes
           tags: |
             type=ref,event=branch

--- a/.gitignore
+++ b/.gitignore
@@ -26,4 +26,4 @@ go.work.sum
 
 # Binaries
 /main
-/signal-receiver
+/signal-api-receiver

--- a/README.md
+++ b/README.md
@@ -1,1 +1,1 @@
-# signal-receiver
+# signal-api-receiver

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/kalbasit/signal-receiver
+module github.com/kalbasit/signal-api-receiver
 
 go 1.22.6
 

--- a/main.go
+++ b/main.go
@@ -7,8 +7,8 @@ import (
 	"net/http"
 	"net/url"
 
-	"github.com/kalbasit/signal-receiver/receiver"
-	"github.com/kalbasit/signal-receiver/server"
+	"github.com/kalbasit/signal-api-receiver/receiver"
+	"github.com/kalbasit/signal-api-receiver/server"
 )
 
 var signalApiURL string

--- a/server/server.go
+++ b/server/server.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"net/http"
 
-	"github.com/kalbasit/signal-receiver/receiver"
+	"github.com/kalbasit/signal-api-receiver/receiver"
 )
 
 const usage = `

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -8,7 +8,7 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/kalbasit/signal-receiver/receiver"
+	"github.com/kalbasit/signal-api-receiver/receiver"
 )
 
 type mockClient struct {


### PR DESCRIPTION
The name `signal-api-receiver` makes more sense than `signal-receiver` and should help with discovery.