### PR TITLE
Allow using a different address with the -addr flag

### DIFF
--- a/main.go
+++ b/main.go
@@ -11,10 +11,12 @@ import (
 	"github.com/kalbasit/signal-api-receiver/server"
 )
 
+var addr string
 var signalApiURL string
 var signalAccount string
 
 func init() {
+	flag.StringVar(&addr, "addr", ":8105", "The address to listen and serve on")
 	flag.StringVar(&signalApiURL, "signal-api-url", "", "The URL of the Signal api including the scheme. e.g wss://signal-api.example.com")
 	flag.StringVar(&signalAccount, "signal-account", "", "The account number for signal")
 }
@@ -48,5 +50,5 @@ func main() {
 	srv := server.New(sarc)
 
 	log.Print("Starting HTTP server on :8105")
-	http.ListenAndServe(":8105", srv)
+	http.ListenAndServe(addr, srv)
 }


### PR DESCRIPTION
By default the server runs on port `8105`, the flag `-addr` can be used to change that.