### PR TITLE
server: Add /healthz for livesness check

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,18 @@ spec:
           ports:
             - containerPort: 8105
               name: receiver-web
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: receiver-web
+            initialDelaySeconds: 15
+            periodSeconds: 20
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: receiver-web
+            initialDelaySeconds: 5
+            periodSeconds: 10
 ```
 
 ## License

--- a/server/server.go
+++ b/server/server.go
@@ -44,6 +44,11 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	if r.URL.Path == "/healthz" {
+		w.WriteHeader(http.StatusNoContent)
+		return
+	}
+
 	if r.URL.Path == "/receive/pop" {
 		msg := s.sarc.Pop()
 		if msg == nil {


### PR DESCRIPTION
Add a route to be used by Kubernetes to check and make sure the service is up and running. `/healthz` that returns a 204 is all that's required.