### PR TITLE
treewide: reconnect receiver and repeat last message

### DIFF
--- a/cmd/signal-api-receiver/main.go
+++ b/cmd/signal-api-receiver/main.go
@@ -14,11 +14,13 @@ import (
 var addr string
 var signalApiURL string
 var signalAccount string
+var repeatLastMessage bool
 
 func init() {
 	flag.StringVar(&addr, "addr", ":8105", "The address to listen and serve on")
 	flag.StringVar(&signalApiURL, "signal-api-url", "", "The URL of the Signal api including the scheme. e.g wss://signal-api.example.com")
 	flag.StringVar(&signalAccount, "signal-account", "", "The account number for signal")
+	flag.BoolVar(&repeatLastMessage, "repeat-last-message", false, "Repeat the last message if there are no new messages (applies to /receive/pop)")
 }
 
 func main() {
@@ -43,11 +45,11 @@ func main() {
 
 	sarc, err := receiver.New(uri)
 	if err != nil {
+		log.Printf("error creating a new websocket connetion: %s", err)
 		panic(err)
 	}
-	go sarc.ReceiveLoop()
 
-	srv := server.New(sarc)
+	srv := server.New(sarc, repeatLastMessage)
 
 	log.Print("Starting HTTP server on :8105")
 	http.ListenAndServe(addr, srv)

--- a/receiver/client.go
+++ b/receiver/client.go
@@ -14,30 +14,80 @@ import (
 // Message defines the message structure received from the Signal API
 type Message struct {
 	Envelope struct {
-		Source        string `json:"source"`
-		SourceNumber  string `json:"sourceNumber"`
-		SourceUUID    string `json:"sourceUuid"`
-		SourceName    string `json:"sourceName"`
-		SourceDevice  int    `json:"sourceDevice"`
-		Timestamp     int64  `json:"timestamp"`
+		Source         string `json:"source"`
+		SourceNumber   string `json:"sourceNumber"`
+		SourceUUID     string `json:"sourceUuid"`
+		SourceName     string `json:"sourceName"`
+		SourceDevice   int    `json:"sourceDevice"`
+		Timestamp      int64  `json:"timestamp"`
+		ReceiptMessage *struct {
+			When       int64   `json:"when"`
+			IsDelivery bool    `json:"isDelivery"`
+			IsRead     bool    `json:"isRead"`
+			IsViewed   bool    `json:"isViewed"`
+			Timestamps []int64 `json:"timestamps"`
+		} `json:"receiptMessage,omitempty"`
 		TypingMessage *struct {
 			Action    string `json:"action"`
 			Timestamp int64  `json:"timestamp"`
 		} `json:"typingMessage,omitempty"`
 		DataMessage *struct {
-			Timestamp        int64  `json:"timestamp"`
-			Message          string `json:"message"`
-			ExpiresInSeconds int    `json:"expiresInSeconds"`
-			ViewOnce         bool   `json:"viewOnce"`
+			Timestamp        int64   `json:"timestamp"`
+			Message          *string `json:"message"`
+			ExpiresInSeconds int     `json:"expiresInSeconds"`
+			ViewOnce         bool    `json:"viewOnce"`
+			GroupInfo        *struct {
+				GroupID   string `json:"groupId"`
+				GroupName string `json:"groupName"`
+				Revision  int64  `json:"revision"`
+				Type      string `json:"type"`
+			} `json:"groupInfo,omitempty"`
+			Quote *struct {
+				ID           int          `json:"id"`
+				Author       string       `json:"author"`
+				AuthorNumber string       `json:"authorNumber"`
+				AuthorUUID   string       `json:"authorUuid"`
+				Text         string       `json:"text"`
+				Attachments  []Attachment `json:"attachments"`
+			} `json:"quote,omitempty"`
+			Mentions []struct {
+				Name   string `json:"name"`
+				Number string `json:"number"`
+				UUID   string `json:"uuid"`
+				Start  int    `json:"start"`
+				Length int    `json:"length"`
+			} `json:"mentions,omitempty"`
+			Sticker *struct {
+				PackID    string `json:"packId"`
+				StickerID int    `json:"stickerId"`
+			} `json:"sticker,omitempty"`
+			Attachments  []Attachment `json:"attachments,omitempty"`
+			RemoteDelete *struct {
+				Timestamp int64 `json:"timestamp"`
+			} `json:"remoteDelete,omitempty"`
 		} `json:"dataMessage,omitempty"`
+		SyncMessage *struct{} `json:"syncMessage,omitempty"`
 	} `json:"envelope"`
 
 	Account string `json:"account"`
 }
 
+// Attachment defines the attachment structure of a message.
+type Attachment struct {
+	ContentType     string  `json:"contentType"`
+	ID              string  `json:"id"`
+	Filename        *string `json:"filename"`
+	Size            int     `json:"size"`
+	Width           *int    `json:"width"`
+	Height          *int    `json:"height"`
+	Caption         *string `json:"caption"`
+	UploadTimestamp *int64  `json:"uploadTimestamp"`
+}
+
 // Client represents the Signal API client, and is returned by the New() function.
 type Client struct {
-	*websocket.Conn
+	uri  *url.URL
+	conn *websocket.Conn
 
 	mu       sync.Mutex
 	messages []Message
@@ -47,27 +97,35 @@ type Client struct {
 // An error is returned if a websocket fails to open with the Signal's API
 // /v1/receive
 func New(uri *url.URL) (*Client, error) {
-	c, _, err := websocket.DefaultDialer.Dial(uri.String(), http.Header{})
-	if err != nil {
-		return nil, fmt.Errorf("error creating a new websocket connetion: %w", err)
+	c := &Client{uri: uri}
+	return c, c.Connect()
+}
+
+func (c *Client) Connect() error {
+	if c.conn != nil {
+		c.conn.Close()
+		c.conn = nil
 	}
 
-	return &Client{
-		Conn:     c,
-		messages: []Message{},
-	}, nil
+	log.Print("Connecting to the Signal API")
+	conn, _, err := websocket.DefaultDialer.Dial(c.uri.String(), http.Header{})
+	if err != nil {
+		return fmt.Errorf("error creating a new websocket connetion: %w", err)
+	}
+	c.conn = conn
+	return nil
 }
 
 // ReceiveLoop is a blocking call and it loop over receiving messages over the
 // websocket and record them internally to be consumed by either Pop() or
 // Flush()
-func (c *Client) ReceiveLoop() {
+func (c *Client) ReceiveLoop() error {
 	log.Print("Starting the receive loop from Signal API")
 	for {
-		_, msg, err := c.ReadMessage()
+		_, msg, err := c.conn.ReadMessage()
 		if err != nil {
-			log.Printf("error returned by the websocket: %s", err)
-			return
+			log.Printf("Error returned by the websocket: %s", err)
+			return err
 		}
 		c.recordMessage(msg)
 	}
@@ -77,7 +135,7 @@ func (c *Client) ReceiveLoop() {
 func (c *Client) Flush() []Message {
 	c.mu.Lock()
 	msgs := c.messages
-	c.messages = []Message{}
+	c.messages = nil
 	c.mu.Unlock()
 	return msgs
 }
@@ -99,13 +157,14 @@ func (c *Client) Pop() *Message {
 func (c *Client) recordMessage(msg []byte) {
 	var m Message
 	if err := json.Unmarshal(msg, &m); err != nil {
-		log.Printf("error decoding the message below: %s", err)
+		log.Printf("Error decoding the message below: %s", err)
 		log.Print(string(msg[:]))
 		return
 	}
 
-	// do not record typing messages
-	if m.Envelope.DataMessage == nil {
+	// Do not record receipt, typing, group update or sync messages, etc.
+	if m.Envelope.DataMessage == nil || m.Envelope.DataMessage.Message == nil {
+		log.Printf("Ignoring non-data message: %s", string(msg))
 		return
 	}
 
@@ -113,5 +172,5 @@ func (c *Client) recordMessage(msg []byte) {
 	c.messages = append(c.messages, m)
 	c.mu.Unlock()
 
-	log.Printf("the following message was successfully recorded: %s", string(msg[:]))
+	log.Printf("The following message was successfully recorded: %s", string(msg))
 }

--- a/receiver/client_test.go
+++ b/receiver/client_test.go
@@ -15,24 +15,24 @@ func TestFlush(t *testing.T) {
 	})
 
 	t.Run("return the message if only one is there", func(t *testing.T) {
-		c := &Client{messages: []Message{Message{Account: "1"}}}
+		c := &Client{messages: []Message{{Account: "1"}}}
 
-		if want, got := []Message{Message{Account: "1"}}, c.Flush(); !reflect.DeepEqual(want, got) {
+		if want, got := []Message{{Account: "1"}}, c.Flush(); !reflect.DeepEqual(want, got) {
 			t.Errorf("want %#v got %#v", want, got)
 		}
 	})
 
 	t.Run("return messages in order", func(t *testing.T) {
 		c := &Client{messages: []Message{
-			Message{Account: "0"},
-			Message{Account: "1"},
-			Message{Account: "2"},
+			{Account: "0"},
+			{Account: "1"},
+			{Account: "2"},
 		}}
 
 		want := []Message{
-			Message{Account: "0"},
-			Message{Account: "1"},
-			Message{Account: "2"},
+			{Account: "0"},
+			{Account: "1"},
+			{Account: "2"},
 		}
 		got := c.Flush()
 		if !reflect.DeepEqual(want, got) {
@@ -51,7 +51,7 @@ func TestPop(t *testing.T) {
 	})
 
 	t.Run("return the message if only one is there", func(t *testing.T) {
-		c := &Client{messages: []Message{Message{Account: "1"}}}
+		c := &Client{messages: []Message{{Account: "1"}}}
 
 		want := Message{Account: "1"}
 		got := c.Pop()
@@ -62,9 +62,9 @@ func TestPop(t *testing.T) {
 
 	t.Run("return messages in order", func(t *testing.T) {
 		c := &Client{messages: []Message{
-			Message{Account: "0"},
-			Message{Account: "1"},
-			Message{Account: "2"},
+			{Account: "0"},
+			{Account: "1"},
+			{Account: "2"},
 		}}
 
 		for i := range c.messages {

--- a/server/server.go
+++ b/server/server.go
@@ -3,7 +3,10 @@ package server
 import (
 	"encoding/json"
 	"fmt"
+	"log"
 	"net/http"
+	"sync/atomic"
+	"time"
 
 	"github.com/kalbasit/signal-api-receiver/receiver"
 )
@@ -15,17 +18,37 @@ GET /receive/flush => Return all messages
 
 // Server represent the HTTP server that exposes the pop/flush routes
 type Server struct {
-	sarc client
+	sarc       client
+	repeatLast bool
+	last       atomic.Pointer[receiver.Message]
 }
 
 type client interface {
+	Connect() error
+	ReceiveLoop() error
 	Pop() *receiver.Message
 	Flush() []receiver.Message
 }
 
 // New returns a new Server
-func New(sarc client) *Server {
-	return &Server{sarc: sarc}
+func New(sarc client, repeatLastMessage bool) *Server {
+	s := &Server{sarc: sarc, repeatLast: repeatLastMessage}
+	go s.start()
+	return s
+}
+
+func (s *Server) start() {
+	for {
+		if err := s.sarc.ReceiveLoop(); err != nil {
+			log.Printf("Error in the receive loop: %v", err)
+		}
+	Reconnect:
+		if err := s.sarc.Connect(); err != nil {
+			log.Printf("Error reconnecting: %v", err)
+			time.Sleep(time.Second)
+			goto Reconnect
+		}
+	}
 }
 
 // ServeHTTP implements the http.Handler interface
@@ -51,6 +74,13 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	if r.URL.Path == "/receive/pop" {
 		msg := s.sarc.Pop()
+		if s.repeatLast {
+			if msg == nil {
+				msg = s.last.Load()
+			} else {
+				s.last.Store(msg)
+			}
+		}
 		if msg == nil {
 			w.WriteHeader(http.StatusNoContent)
 			return
@@ -65,6 +95,9 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	if r.URL.Path == "/receive/flush" {
 		msgs := s.sarc.Flush()
+		if s.repeatLast && len(msgs) > 0 {
+			s.last.Store(&msgs[len(msgs)-1])
+		}
 		w.Header().Set("Content-Type", "application/json")
 		if err := json.NewEncoder(w).Encode(msgs); err != nil {
 			w.WriteHeader(http.StatusInternalServerError)

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -15,6 +15,16 @@ type mockClient struct {
 	msgs []receiver.Message
 }
 
+func (mc *mockClient) Connect() error {
+	return nil
+}
+
+func (mc *mockClient) ReceiveLoop() error {
+	var ch chan struct{}
+	<-ch
+	return nil
+}
+
 func (mc *mockClient) Pop() *receiver.Message {
 	if len(mc.msgs) == 0 {
 		return nil
@@ -34,8 +44,8 @@ func (mc *mockClient) Flush() []receiver.Message {
 
 func TestServeHTTP(t *testing.T) {
 	mc := &mockClient{msgs: []receiver.Message{}}
-	s := Server{sarc: mc}
-	hs := httptest.NewServer(&s)
+	s := New(mc, true)
+	hs := httptest.NewServer(s)
 	defer hs.Close()
 
 	t.Run("GET /receive/pop", func(t *testing.T) {
@@ -81,9 +91,9 @@ func TestServeHTTP(t *testing.T) {
 
 		t.Run("three messages in the queue", func(t *testing.T) {
 			want := []receiver.Message{
-				receiver.Message{Account: "0"},
-				receiver.Message{Account: "1"},
-				receiver.Message{Account: "2"},
+				{Account: "0"},
+				{Account: "1"},
+				{Account: "2"},
 			}
 			mc.msgs = want
 
@@ -146,7 +156,7 @@ func TestServeHTTP(t *testing.T) {
 		})
 
 		t.Run("one message in the queue", func(t *testing.T) {
-			want := []receiver.Message{receiver.Message{Account: "0"}}
+			want := []receiver.Message{{Account: "0"}}
 			mc.msgs = want
 
 			resp, err := http.Get(hs.URL + "/receive/flush")
@@ -175,9 +185,9 @@ func TestServeHTTP(t *testing.T) {
 
 		t.Run("three messages in the queue", func(t *testing.T) {
 			want := []receiver.Message{
-				receiver.Message{Account: "0"},
-				receiver.Message{Account: "1"},
-				receiver.Message{Account: "2"},
+				{Account: "0"},
+				{Account: "1"},
+				{Account: "2"},
 			}
 			mc.msgs = want
 


### PR DESCRIPTION
This PR adds support for reconnecting the WebSocket on error and implements a new feature to repeat the last message for `/receive/pop`.

Previously the API was left running but no new messages received if e.g. signal-cli-rest-api was restarted.

The repeat the last message feature is useful in Home Assistant to avoid clearing the sensor status on next scan.

Thanks for creating the project, came in handy. And I pretty much skipped writing tests for the new functionality so let me know if you want me to add those. Cheers.
