### PR TITLE
docs: Update the k8s manifest with the new binary location

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ spec:
         - image: kalbasit/signal-receiver:latest
           name: signal-receiver
           args:
-            - /app/signal-api-receiver
+            - /bin/signal-api-receiver
             - -signal-api-url=wss://signal-api.example.com
             - -signal-account=+19876543210
           ports:


### PR DESCRIPTION
Fix is required after #13 went in.