### PR TITLE
test: Migrate to testify assertions

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,3 +3,10 @@ module github.com/kalbasit/signal-api-receiver
 go 1.23.3
 
 require github.com/gorilla/websocket v1.5.3
+
+require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/stretchr/testify v1.10.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
+)

--- a/go.mod
+++ b/go.mod
@@ -2,11 +2,13 @@ module github.com/kalbasit/signal-api-receiver
 
 go 1.23.3
 
-require github.com/gorilla/websocket v1.5.3
+require (
+	github.com/gorilla/websocket v1.5.3
+	github.com/stretchr/testify v1.10.0
+)
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	github.com/stretchr/testify v1.10.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -6,6 +6,7 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
 github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,11 @@
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/gorilla/websocket v1.5.3 h1:saDtZ6Pbx/0u+bgYQ3q96pZgCzfhKXGPqt7kZ72aNNg=
 github.com/gorilla/websocket v1.5.3/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
+github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/nix/packages/signal-api-receiver.nix
+++ b/nix/packages/signal-api-receiver.nix
@@ -27,7 +27,7 @@
 
           subPackages = [ "." ];
 
-          vendorHash = "sha256-0Qxw+MUYVgzgWB8vi3HBYtVXSq/btfh4ZfV/m1chNrA=";
+          vendorHash = "sha256-ZWlUjQXnIk5aamIJ6cZxE8Vysx3hNJ5zeOiptvbSD0M=";
 
           doCheck = true;
 

--- a/receiver/client_test.go
+++ b/receiver/client_test.go
@@ -1,25 +1,22 @@
 package receiver
 
 import (
-	"reflect"
 	"strconv"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestFlush(t *testing.T) {
 	t.Run("returns empty list when no messages was found", func(t *testing.T) {
 		c := &Client{messages: []Message{}}
-		if want, got := []Message{}, c.Flush(); !reflect.DeepEqual(want, got) {
-			t.Errorf("want %#v got %#v", want, got)
-		}
+		assert.Equal(t, []Message{}, c.Flush())
 	})
 
 	t.Run("return the message if only one is there", func(t *testing.T) {
 		c := &Client{messages: []Message{{Account: "1"}}}
 
-		if want, got := []Message{{Account: "1"}}, c.Flush(); !reflect.DeepEqual(want, got) {
-			t.Errorf("want %#v got %#v", want, got)
-		}
+		assert.Equal(t, []Message{{Account: "1"}}, c.Flush())
 	})
 
 	t.Run("return messages in order", func(t *testing.T) {
@@ -35,9 +32,8 @@ func TestFlush(t *testing.T) {
 			{Account: "2"},
 		}
 		got := c.Flush()
-		if !reflect.DeepEqual(want, got) {
-			t.Errorf("want\n%#v\ngot\n%#v", want, got)
-		}
+
+		assert.Equal(t, want, got)
 	})
 }
 
@@ -45,19 +41,13 @@ func TestPop(t *testing.T) {
 	t.Run("returns null when no messages was found", func(t *testing.T) {
 		c := &Client{messages: []Message{}}
 		var want *Message
-		if got := c.Pop(); want != got {
-			t.Errorf("want %#v got %#v", want, got)
-		}
+		assert.Equal(t, want, c.Pop())
 	})
 
 	t.Run("return the message if only one is there", func(t *testing.T) {
 		c := &Client{messages: []Message{{Account: "1"}}}
-
 		want := Message{Account: "1"}
-		got := c.Pop()
-		if !reflect.DeepEqual(want, *got) {
-			t.Errorf("want\n%#v\ngot\n%#v", want, got)
-		}
+		assert.Equal(t, want, *c.Pop())
 	})
 
 	t.Run("return messages in order", func(t *testing.T) {
@@ -69,10 +59,7 @@ func TestPop(t *testing.T) {
 
 		for i := range c.messages {
 			want := Message{Account: strconv.Itoa(i)}
-			got := c.Pop()
-			if !reflect.DeepEqual(want, *got) {
-				t.Errorf("want\n%#v\ngot\n%#v", want, got)
-			}
+			assert.Equal(t, want, *c.Pop())
 		}
 	})
 }

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -5,8 +5,10 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
-	"reflect"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/kalbasit/signal-api-receiver/receiver"
 )
@@ -43,12 +45,9 @@ func TestServeHTTP(t *testing.T) {
 			mc.msgs = []receiver.Message{}
 
 			resp, err := http.Get(hs.URL + "/receive/pop")
-			if err != nil {
-				t.Fatalf("expected no error, got: %s", err)
-			}
-			if want, got := http.StatusNoContent, resp.StatusCode; want != got {
-				t.Errorf("want %s, got %s", http.StatusText(want), http.StatusText(got))
-			}
+			require.NoError(t, err)
+
+			assert.Equal(t, http.StatusNoContent, resp.StatusCode)
 		})
 
 		t.Run("one message in the queue", func(t *testing.T) {
@@ -56,27 +55,19 @@ func TestServeHTTP(t *testing.T) {
 			mc.msgs = []receiver.Message{want}
 
 			resp, err := http.Get(hs.URL + "/receive/pop")
-			if err != nil {
-				t.Fatalf("expected no error, got: %s", err)
-			}
-			if want, got := http.StatusOK, resp.StatusCode; want != got {
-				t.Errorf("want %s, got %s", http.StatusText(want), http.StatusText(got))
-			}
+			require.NoError(t, err)
+
+			defer resp.Body.Close()
+
+			assert.Equal(t, http.StatusOK, resp.StatusCode)
 
 			body, err := io.ReadAll(resp.Body)
-			resp.Body.Close()
-			if err != nil {
-				t.Fatalf("expected no error, got: %s", err)
-			}
+			require.NoError(t, err)
 
 			var got receiver.Message
-			if err := json.Unmarshal(body, &got); err != nil {
-				t.Fatalf("expected no error, got: %s", err)
-			}
+			require.NoError(t, json.Unmarshal(body, &got))
 
-			if !reflect.DeepEqual(want, got) {
-				t.Errorf("want\n%#v\ngot\n%#v", want, got)
-			}
+			assert.Equal(t, want, got)
 		})
 
 		t.Run("three messages in the queue", func(t *testing.T) {
@@ -91,29 +82,21 @@ func TestServeHTTP(t *testing.T) {
 
 			for range want {
 				resp, err := http.Get(hs.URL + "/receive/pop")
-				if err != nil {
-					t.Fatalf("expected no error, got: %s", err)
-				}
-				if want, got := http.StatusOK, resp.StatusCode; want != got {
-					t.Errorf("want %s, got %s", http.StatusText(want), http.StatusText(got))
-				}
+				require.NoError(t, err)
+
+				defer resp.Body.Close()
+
+				assert.Equal(t, http.StatusOK, resp.StatusCode)
 
 				body, err := io.ReadAll(resp.Body)
-				resp.Body.Close()
-				if err != nil {
-					t.Fatalf("expected no error, got: %s", err)
-				}
+				require.NoError(t, err)
 
 				var m receiver.Message
-				if err := json.Unmarshal(body, &m); err != nil {
-					t.Fatalf("expected no error, got: %s", err)
-				}
+				require.NoError(t, json.Unmarshal(body, &m))
 				got = append(got, m)
 			}
 
-			if !reflect.DeepEqual(want, got) {
-				t.Errorf("want\n%#v\ngot\n%#v", want, got)
-			}
+			assert.Equal(t, want, got)
 		})
 	})
 
@@ -122,27 +105,19 @@ func TestServeHTTP(t *testing.T) {
 			mc.msgs = []receiver.Message{}
 
 			resp, err := http.Get(hs.URL + "/receive/flush")
-			if err != nil {
-				t.Fatalf("expected no error, got: %s", err)
-			}
-			if want, got := http.StatusOK, resp.StatusCode; want != got {
-				t.Errorf("want %s, got %s", http.StatusText(want), http.StatusText(got))
-			}
+			require.NoError(t, err)
+
+			defer resp.Body.Close()
+
+			assert.Equal(t, http.StatusOK, resp.StatusCode)
 
 			body, err := io.ReadAll(resp.Body)
-			resp.Body.Close()
-			if err != nil {
-				t.Fatalf("expected no error, got: %s", err)
-			}
+			require.NoError(t, err)
 
 			var got []receiver.Message
-			if err := json.Unmarshal(body, &got); err != nil {
-				t.Fatalf("expected no error, got: %s", err)
-			}
+			require.NoError(t, json.Unmarshal(body, &got))
 
-			if len(got) != 0 {
-				t.Errorf("expected an empty response, got\n%#v", got)
-			}
+			assert.Empty(t, got)
 		})
 
 		t.Run("one message in the queue", func(t *testing.T) {
@@ -150,27 +125,19 @@ func TestServeHTTP(t *testing.T) {
 			mc.msgs = want
 
 			resp, err := http.Get(hs.URL + "/receive/flush")
-			if err != nil {
-				t.Fatalf("expected no error, got: %s", err)
-			}
-			if want, got := http.StatusOK, resp.StatusCode; want != got {
-				t.Errorf("want %s, got %s", http.StatusText(want), http.StatusText(got))
-			}
+			require.NoError(t, err)
+
+			defer resp.Body.Close()
+
+			assert.Equal(t, http.StatusOK, resp.StatusCode)
 
 			body, err := io.ReadAll(resp.Body)
-			resp.Body.Close()
-			if err != nil {
-				t.Fatalf("expected no error, got: %s", err)
-			}
+			require.NoError(t, err)
 
 			var got []receiver.Message
-			if err := json.Unmarshal(body, &got); err != nil {
-				t.Fatalf("expected no error, got: %s", err)
-			}
+			require.NoError(t, json.Unmarshal(body, &got))
 
-			if !reflect.DeepEqual(want, got) {
-				t.Errorf("want\n%#v\ngot\n%#v", want, got)
-			}
+			assert.Equal(t, want, got)
 		})
 
 		t.Run("three messages in the queue", func(t *testing.T) {
@@ -182,27 +149,19 @@ func TestServeHTTP(t *testing.T) {
 			mc.msgs = want
 
 			resp, err := http.Get(hs.URL + "/receive/flush")
-			if err != nil {
-				t.Fatalf("expected no error, got: %s", err)
-			}
-			if want, got := http.StatusOK, resp.StatusCode; want != got {
-				t.Errorf("want %s, got %s", http.StatusText(want), http.StatusText(got))
-			}
+			require.NoError(t, err)
+
+			defer resp.Body.Close()
+
+			assert.Equal(t, http.StatusOK, resp.StatusCode)
 
 			body, err := io.ReadAll(resp.Body)
-			resp.Body.Close()
-			if err != nil {
-				t.Fatalf("expected no error, got: %s", err)
-			}
+			require.NoError(t, err)
 
 			var got []receiver.Message
-			if err := json.Unmarshal(body, &got); err != nil {
-				t.Fatalf("expected no error, got: %s", err)
-			}
+			require.NoError(t, json.Unmarshal(body, &got))
 
-			if !reflect.DeepEqual(want, got) {
-				t.Errorf("want\n%#v\ngot\n%#v", want, got)
-			}
+			assert.Equal(t, want, got)
 		})
 	})
 
@@ -212,44 +171,26 @@ func TestServeHTTP(t *testing.T) {
 		for _, verb := range []string{"POST", "PUT", "PATCH", "DELETE"} {
 			t.Run(verb+" /", func(t *testing.T) {
 				r, err := http.NewRequest(verb, hs.URL, nil)
-				if err != nil {
-					t.Fatalf("expected no error, got: %s", err)
-				}
+				require.NoError(t, err)
 				resp, err := http.DefaultClient.Do(r)
-				if err != nil {
-					t.Fatalf("expected no error, got: %s", err)
-				}
-				if want, got := http.StatusForbidden, resp.StatusCode; want != got {
-					t.Errorf("want %s, got %s", http.StatusText(want), http.StatusText(got))
-				}
+				require.NoError(t, err)
+				assert.Equal(t, http.StatusForbidden, resp.StatusCode)
 			})
 
 			t.Run(verb+" /receive/flush", func(t *testing.T) {
 				r, err := http.NewRequest(verb, hs.URL+"/receive/flush", nil)
-				if err != nil {
-					t.Fatalf("expected no error, got: %s", err)
-				}
+				require.NoError(t, err)
 				resp, err := http.DefaultClient.Do(r)
-				if err != nil {
-					t.Fatalf("expected no error, got: %s", err)
-				}
-				if want, got := http.StatusForbidden, resp.StatusCode; want != got {
-					t.Errorf("want %s, got %s", http.StatusText(want), http.StatusText(got))
-				}
+				require.NoError(t, err)
+				assert.Equal(t, http.StatusForbidden, resp.StatusCode)
 			})
 
 			t.Run(verb+" /receive/pop", func(t *testing.T) {
 				r, err := http.NewRequest(verb, hs.URL+"/receive/pop", nil)
-				if err != nil {
-					t.Fatalf("expected no error, got: %s", err)
-				}
+				require.NoError(t, err)
 				resp, err := http.DefaultClient.Do(r)
-				if err != nil {
-					t.Fatalf("expected no error, got: %s", err)
-				}
-				if want, got := http.StatusForbidden, resp.StatusCode; want != got {
-					t.Errorf("want %s, got %s", http.StatusText(want), http.StatusText(got))
-				}
+				require.NoError(t, err)
+				assert.Equal(t, http.StatusForbidden, resp.StatusCode)
 			})
 		}
 	})


### PR DESCRIPTION
Add testify dependency and convert tests to use assert/require

Convert server_test.go to use testify assertions and cleanup error handling

Convert client_test.go to use testify assertions

Update go.mod and go.sum with testify and dependencies

Update vendorHash in nix package definition