### PR TITLE
chore(treewide): Add linting and improve code quality

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,60 @@
+linters:
+  enable:
+    - errname
+    - err113
+    - exhaustive
+    - gci
+    - gochecknoglobals
+    - gochecknoinits
+    - goconst
+    - godot
+    - gofumpt
+    - goheader
+    - goimports
+    - gosec
+    - importas
+    - lll
+    - makezero
+    - misspell
+    - nakedret
+    - nestif
+    - nilerr
+    - nilnil
+    - nlreturn
+    - noctx
+    - nolintlint
+    - paralleltest
+    - prealloc
+    - predeclared
+    - revive
+    - rowserrcheck
+    - stylecheck
+    - tagliatelle
+    - tenv
+    - testifylint
+    - testpackage
+    - unconvert
+    - unparam
+    - wastedassign
+    - whitespace
+    - wsl
+    - zerologlint
+linters-settings:
+  gci:
+    # Section configuration to compare against.
+    # Section names are case-insensitive and may contain parameters in ().
+    # The default order of sections is `standard > default > custom > blank > dot > alias > localmodule`,
+    # If `custom-order` is `true`, it follows the order of `sections` option.
+    # Default: ["standard", "default"]
+    sections:
+      - standard # Standard section: captures all standard packages.
+      - default # Default section: contains all imports that could not be matched to another section type.
+      - alias # Alias section: contains all alias imports. This section is not present unless explicitly enabled.
+      # - prefix(github.com/org/project) # Custom section: groups all imports with the specified Prefix.
+      - localmodule # Local module section: contains all local packages. This section is not present unless explicitly enabled.
+      - blank # Blank section: contains all blank imports. This section is not present unless explicitly enabled.
+      - dot # Dot section: contains all dot imports. This section is not present unless explicitly enabled.
+    # Enable custom order of sections.
+    # If `true`, make the section order the same as the order of `sections`.
+    # Default: false
+    custom-order: true

--- a/main.go
+++ b/main.go
@@ -17,13 +17,11 @@ var (
 	signalAccount string
 )
 
-func init() {
+func main() {
 	flag.StringVar(&addr, "addr", ":8105", "The address to listen and serve on")
 	flag.StringVar(&signalApiURL, "signal-api-url", "", "The URL of the Signal api including the scheme. e.g wss://signal-api.example.com")
 	flag.StringVar(&signalAccount, "signal-account", "", "The account number for signal")
-}
 
-func main() {
 	flag.Parse()
 
 	uri, err := url.Parse(signalApiURL)
@@ -51,7 +49,7 @@ func main() {
 
 	srv := server.New(sarc)
 
-	log.Print("Starting HTTP server on :8105")
+	log.Printf("Starting HTTP server on %s", addr)
 
 	if err := http.ListenAndServe(addr, srv); err != nil {
 		log.Printf("error starting the server on %q: %s", addr, err)

--- a/main.go
+++ b/main.go
@@ -6,36 +6,48 @@ import (
 	"log"
 	"net/http"
 	"net/url"
+	"os"
+	"time"
 
 	"github.com/kalbasit/signal-api-receiver/receiver"
 	"github.com/kalbasit/signal-api-receiver/server"
 )
 
-var (
-	addr          string
-	signalApiURL  string
-	signalAccount string
-)
-
 func main() {
+	os.Exit(realMain())
+}
+
+func realMain() int {
+	var (
+		addr          string
+		signalAPIURL  string
+		signalAccount string
+	)
+
 	flag.StringVar(&addr, "addr", ":8105", "The address to listen and serve on")
-	flag.StringVar(&signalApiURL, "signal-api-url", "", "The URL of the Signal api including the scheme. e.g wss://signal-api.example.com")
+	flag.StringVar(&signalAPIURL, "signal-api-url", "",
+		"The URL of the Signal api including the scheme. e.g wss://signal-api.example.com")
 	flag.StringVar(&signalAccount, "signal-account", "", "The account number for signal")
 
 	flag.Parse()
 
-	uri, err := url.Parse(signalApiURL)
+	uri, err := url.Parse(signalAPIURL)
 	if err != nil {
-		log.Printf("error parsing the url %q: %s", signalApiURL, err)
-		return
+		log.Printf("error parsing the url %q: %s", signalAPIURL, err)
+
+		return 1
 	}
+
 	if uri.Scheme == "" {
 		log.Printf("the given url %q does not contain a scheme", uri)
-		return
+
+		return 1
 	}
+
 	if uri.Host == "" {
 		log.Printf("the given url %q does not contain a host", uri)
-		return
+
+		return 1
 	}
 
 	uri.Path = fmt.Sprintf("/v1/receive/%s", signalAccount)
@@ -43,15 +55,28 @@ func main() {
 
 	sarc, err := receiver.New(uri)
 	if err != nil {
-		panic(err)
+		log.Printf("error creating a new receiver: %s", err)
+
+		return 1
 	}
+
 	go sarc.ReceiveLoop()
 
 	srv := server.New(sarc)
 
+	server := &http.Server{
+		Addr:              addr,
+		Handler:           srv,
+		ReadHeaderTimeout: 10 * time.Second,
+	}
+
 	log.Printf("Starting HTTP server on %s", addr)
 
-	if err := http.ListenAndServe(addr, srv); err != nil {
+	if err := server.ListenAndServe(); err != nil {
 		log.Printf("error starting the server on %q: %s", addr, err)
+
+		return 1
 	}
+
+	return 0
 }

--- a/receiver/client.go
+++ b/receiver/client.go
@@ -11,7 +11,7 @@ import (
 	"github.com/gorilla/websocket"
 )
 
-// Message defines the message structure received from the Signal API
+// Message defines the message structure received from the Signal API.
 type Message struct {
 	Envelope struct {
 		Source        string `json:"source"`
@@ -45,7 +45,7 @@ type Client struct {
 
 // New creates a new Signal API client and returns it.
 // An error is returned if a websocket fails to open with the Signal's API
-// /v1/receive
+// /v1/receive.
 func New(uri *url.URL) (*Client, error) {
 	c, _, err := websocket.DefaultDialer.Dial(uri.String(), http.Header{})
 	if err != nil {
@@ -60,7 +60,7 @@ func New(uri *url.URL) (*Client, error) {
 
 // ReceiveLoop is a blocking call and it loop over receiving messages over the
 // websocket and record them internally to be consumed by either Pop() or
-// Flush()
+// Flush().
 func (c *Client) ReceiveLoop() {
 	log.Print("Starting the receive loop from Signal API")
 	for {
@@ -73,7 +73,7 @@ func (c *Client) ReceiveLoop() {
 	}
 }
 
-// Flush empties out the internal queue of messages and returns them
+// Flush empties out the internal queue of messages and returns them.
 func (c *Client) Flush() []Message {
 	c.mu.Lock()
 	msgs := c.messages
@@ -82,7 +82,7 @@ func (c *Client) Flush() []Message {
 	return msgs
 }
 
-// Pop returns the oldest message in the queue or null if no message was found
+// Pop returns the oldest message in the queue or null if no message was found.
 func (c *Client) Pop() *Message {
 	c.mu.Lock()
 	if len(c.messages) == 0 {

--- a/receiver/client.go
+++ b/receiver/client.go
@@ -63,12 +63,15 @@ func New(uri *url.URL) (*Client, error) {
 // Flush().
 func (c *Client) ReceiveLoop() {
 	log.Print("Starting the receive loop from Signal API")
+
 	for {
 		_, msg, err := c.ReadMessage()
 		if err != nil {
 			log.Printf("error returned by the websocket: %s", err)
+
 			return
 		}
+
 		c.recordMessage(msg)
 	}
 }
@@ -79,19 +82,21 @@ func (c *Client) Flush() []Message {
 	msgs := c.messages
 	c.messages = []Message{}
 	c.mu.Unlock()
+
 	return msgs
 }
 
 // Pop returns the oldest message in the queue or null if no message was found.
 func (c *Client) Pop() *Message {
 	c.mu.Lock()
+	defer c.mu.Unlock()
+
 	if len(c.messages) == 0 {
-		c.mu.Unlock()
 		return nil
 	}
+
 	msg := c.messages[0]
 	c.messages = c.messages[1:]
-	c.mu.Unlock()
 
 	return &msg
 }
@@ -101,6 +106,7 @@ func (c *Client) recordMessage(msg []byte) {
 	if err := json.Unmarshal(msg, &m); err != nil {
 		log.Printf("error decoding the message below: %s", err)
 		log.Print(string(msg[:]))
+
 		return
 	}
 

--- a/receiver/client_test.go
+++ b/receiver/client_test.go
@@ -1,3 +1,4 @@
+//nolint:testpackage
 package receiver
 
 import (
@@ -52,7 +53,9 @@ func TestPop(t *testing.T) {
 		t.Parallel()
 
 		c := &Client{messages: []Message{}}
+
 		var want *Message
+
 		assert.Equal(t, want, c.Pop())
 	})
 

--- a/receiver/client_test.go
+++ b/receiver/client_test.go
@@ -8,18 +8,26 @@ import (
 )
 
 func TestFlush(t *testing.T) {
+	t.Parallel()
+
 	t.Run("returns empty list when no messages was found", func(t *testing.T) {
+		t.Parallel()
+
 		c := &Client{messages: []Message{}}
 		assert.Equal(t, []Message{}, c.Flush())
 	})
 
 	t.Run("return the message if only one is there", func(t *testing.T) {
+		t.Parallel()
+
 		c := &Client{messages: []Message{{Account: "1"}}}
 
 		assert.Equal(t, []Message{{Account: "1"}}, c.Flush())
 	})
 
 	t.Run("return messages in order", func(t *testing.T) {
+		t.Parallel()
+
 		c := &Client{messages: []Message{
 			{Account: "0"},
 			{Account: "1"},
@@ -38,19 +46,27 @@ func TestFlush(t *testing.T) {
 }
 
 func TestPop(t *testing.T) {
+	t.Parallel()
+
 	t.Run("returns null when no messages was found", func(t *testing.T) {
+		t.Parallel()
+
 		c := &Client{messages: []Message{}}
 		var want *Message
 		assert.Equal(t, want, c.Pop())
 	})
 
 	t.Run("return the message if only one is there", func(t *testing.T) {
+		t.Parallel()
+
 		c := &Client{messages: []Message{{Account: "1"}}}
 		want := Message{Account: "1"}
 		assert.Equal(t, want, *c.Pop())
 	})
 
 	t.Run("return messages in order", func(t *testing.T) {
+		t.Parallel()
+
 		c := &Client{messages: []Message{
 			{Account: "0"},
 			{Account: "1"},

--- a/server/server.go
+++ b/server/server.go
@@ -14,7 +14,7 @@ GET /receive/pop   => Return the oldest message
 GET /receive/flush => Return all messages
 `
 
-// Server represent the HTTP server that exposes the pop/flush routes
+// Server represent the HTTP server that exposes the pop/flush routes.
 type Server struct {
 	sarc client
 }
@@ -24,7 +24,7 @@ type client interface {
 	Flush() []receiver.Message
 }
 
-// New returns a new Server
+// New returns a new Server.
 func New(sarc client) *Server {
 	return &Server{sarc: sarc}
 }

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -35,13 +35,21 @@ func (mc *mockClient) Flush() []receiver.Message {
 }
 
 func TestServeHTTP(t *testing.T) {
-	mc := &mockClient{msgs: []receiver.Message{}}
-	s := Server{sarc: mc}
-	hs := httptest.NewServer(&s)
-	defer hs.Close()
+	t.Parallel()
 
 	t.Run("GET /receive/pop", func(t *testing.T) {
+		t.Parallel()
+
 		t.Run("no messages in the queue", func(t *testing.T) {
+			t.Parallel()
+
+			mc := &mockClient{msgs: []receiver.Message{}}
+
+			s := Server{sarc: mc}
+
+			hs := httptest.NewServer(&s)
+			defer hs.Close()
+
 			mc.msgs = []receiver.Message{}
 
 			resp, err := http.Get(hs.URL + "/receive/pop")
@@ -51,6 +59,15 @@ func TestServeHTTP(t *testing.T) {
 		})
 
 		t.Run("one message in the queue", func(t *testing.T) {
+			t.Parallel()
+
+			mc := &mockClient{msgs: []receiver.Message{}}
+
+			s := Server{sarc: mc}
+
+			hs := httptest.NewServer(&s)
+			defer hs.Close()
+
 			want := receiver.Message{Account: "0"}
 			mc.msgs = []receiver.Message{want}
 
@@ -65,12 +82,22 @@ func TestServeHTTP(t *testing.T) {
 			require.NoError(t, err)
 
 			var got receiver.Message
+
 			require.NoError(t, json.Unmarshal(body, &got))
 
 			assert.Equal(t, want, got)
 		})
 
 		t.Run("three messages in the queue", func(t *testing.T) {
+			t.Parallel()
+
+			mc := &mockClient{msgs: []receiver.Message{}}
+
+			s := Server{sarc: mc}
+
+			hs := httptest.NewServer(&s)
+			defer hs.Close()
+
 			want := []receiver.Message{
 				{Account: "0"},
 				{Account: "1"},
@@ -92,7 +119,9 @@ func TestServeHTTP(t *testing.T) {
 				require.NoError(t, err)
 
 				var m receiver.Message
+
 				require.NoError(t, json.Unmarshal(body, &m))
+
 				got = append(got, m)
 			}
 
@@ -101,7 +130,18 @@ func TestServeHTTP(t *testing.T) {
 	})
 
 	t.Run("GET /receive/flush", func(t *testing.T) {
+		t.Parallel()
+
 		t.Run("no messages in the queue", func(t *testing.T) {
+			t.Parallel()
+
+			mc := &mockClient{msgs: []receiver.Message{}}
+
+			s := Server{sarc: mc}
+
+			hs := httptest.NewServer(&s)
+			defer hs.Close()
+
 			mc.msgs = []receiver.Message{}
 
 			resp, err := http.Get(hs.URL + "/receive/flush")
@@ -115,12 +155,22 @@ func TestServeHTTP(t *testing.T) {
 			require.NoError(t, err)
 
 			var got []receiver.Message
+
 			require.NoError(t, json.Unmarshal(body, &got))
 
 			assert.Empty(t, got)
 		})
 
 		t.Run("one message in the queue", func(t *testing.T) {
+			t.Parallel()
+
+			mc := &mockClient{msgs: []receiver.Message{}}
+
+			s := Server{sarc: mc}
+
+			hs := httptest.NewServer(&s)
+			defer hs.Close()
+
 			want := []receiver.Message{{Account: "0"}}
 			mc.msgs = want
 
@@ -135,12 +185,22 @@ func TestServeHTTP(t *testing.T) {
 			require.NoError(t, err)
 
 			var got []receiver.Message
+
 			require.NoError(t, json.Unmarshal(body, &got))
 
 			assert.Equal(t, want, got)
 		})
 
 		t.Run("three messages in the queue", func(t *testing.T) {
+			t.Parallel()
+
+			mc := &mockClient{msgs: []receiver.Message{}}
+
+			s := Server{sarc: mc}
+
+			hs := httptest.NewServer(&s)
+			defer hs.Close()
+
 			want := []receiver.Message{
 				{Account: "0"},
 				{Account: "1"},
@@ -159,6 +219,7 @@ func TestServeHTTP(t *testing.T) {
 			require.NoError(t, err)
 
 			var got []receiver.Message
+
 			require.NoError(t, json.Unmarshal(body, &got))
 
 			assert.Equal(t, want, got)
@@ -166,10 +227,19 @@ func TestServeHTTP(t *testing.T) {
 	})
 
 	t.Run("anything else", func(t *testing.T) {
-		mc.msgs = []receiver.Message{}
+		t.Parallel()
 
 		for _, verb := range []string{"POST", "PUT", "PATCH", "DELETE"} {
 			t.Run(verb+" /", func(t *testing.T) {
+				t.Parallel()
+
+				mc := &mockClient{msgs: []receiver.Message{}}
+
+				s := Server{sarc: mc}
+
+				hs := httptest.NewServer(&s)
+				defer hs.Close()
+
 				r, err := http.NewRequest(verb, hs.URL, nil)
 				require.NoError(t, err)
 				resp, err := http.DefaultClient.Do(r)
@@ -178,6 +248,15 @@ func TestServeHTTP(t *testing.T) {
 			})
 
 			t.Run(verb+" /receive/flush", func(t *testing.T) {
+				t.Parallel()
+
+				mc := &mockClient{msgs: []receiver.Message{}}
+
+				s := Server{sarc: mc}
+
+				hs := httptest.NewServer(&s)
+				defer hs.Close()
+
 				r, err := http.NewRequest(verb, hs.URL+"/receive/flush", nil)
 				require.NoError(t, err)
 				resp, err := http.DefaultClient.Do(r)
@@ -186,6 +265,15 @@ func TestServeHTTP(t *testing.T) {
 			})
 
 			t.Run(verb+" /receive/pop", func(t *testing.T) {
+				t.Parallel()
+
+				mc := &mockClient{msgs: []receiver.Message{}}
+
+				s := Server{sarc: mc}
+
+				hs := httptest.NewServer(&s)
+				defer hs.Close()
+
 				r, err := http.NewRequest(verb, hs.URL+"/receive/pop", nil)
 				require.NoError(t, err)
 				resp, err := http.DefaultClient.Do(r)


### PR DESCRIPTION
Add golangci-lint configuration and code quality improvements

* Add `.golangci.yml` with comprehensive linter configuration
* Move initialization code from `init()` to `main()`
* Add proper error handling and return codes
* Improve HTTP server configuration with timeouts
* Add parallel test execution
* Improve error responses in server package
* Move server tests to separate package
* Add proper context handling in tests
* Fix documentation formatting and periods
* Improve code organization and readability