### PR TITLE
refactor: server should start the receive loop

### DIFF
--- a/main.go
+++ b/main.go
@@ -60,8 +60,6 @@ func realMain() int {
 		return 1
 	}
 
-	go sarc.ReceiveLoop()
-
 	srv := server.New(sarc)
 
 	server := &http.Server{

--- a/receiver/client.go
+++ b/receiver/client.go
@@ -110,7 +110,7 @@ func New(uri *url.URL) (*Client, error) {
 // ReceiveLoop is a blocking call and it loop over receiving messages over the
 // websocket and record them internally to be consumed by either Pop() or
 // Flush().
-func (c *Client) ReceiveLoop() {
+func (c *Client) ReceiveLoop() error {
 	log.Print("Starting the receive loop from Signal API")
 
 	for {
@@ -118,7 +118,7 @@ func (c *Client) ReceiveLoop() {
 		if err != nil {
 			log.Printf("error returned by the websocket: %s", err)
 
-			return
+			return err
 		}
 
 		c.recordMessage(msg)

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -19,6 +19,10 @@ type mockClient struct {
 	msgs []receiver.Message
 }
 
+func (mc *mockClient) ReceiveLoop() error {
+	return nil
+}
+
 func (mc *mockClient) Pop() *receiver.Message {
 	if len(mc.msgs) == 0 {
 		return nil


### PR DESCRIPTION
Move the receive loop into the server package and make it restart on error

The receive loop is now managed by the server package, which will restart it automatically if it encounters an error. The loop previously lived in main.go but has been relocated to server.go for better error handling and recovery.

ref #8

Co-authored-by: Mathias Fredriksson <mafredri@gmail.com>