### PR TITLE
fix(receiver): Reconnect websocket if receiving errors out

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log"
 	"net/http"
+	"time"
 
 	"github.com/kalbasit/signal-api-receiver/receiver"
 )
@@ -20,6 +21,7 @@ type Server struct {
 }
 
 type client interface {
+	Connect() error
 	ReceiveLoop() error
 	Pop() *receiver.Message
 	Flush() []receiver.Message
@@ -37,6 +39,13 @@ func (s *Server) start() {
 	for {
 		if err := s.sarc.ReceiveLoop(); err != nil {
 			log.Printf("Error in the receive loop: %v", err)
+		}
+	Reconnect:
+		if err := s.sarc.Connect(); err != nil {
+			log.Printf("Error reconnecting: %v", err)
+			time.Sleep(time.Second)
+
+			goto Reconnect
 		}
 	}
 }

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -19,6 +19,10 @@ type mockClient struct {
 	msgs []receiver.Message
 }
 
+func (mc *mockClient) Connect() error {
+	return nil
+}
+
 func (mc *mockClient) ReceiveLoop() error {
 	return nil
 }


### PR DESCRIPTION
Adds automatic reconnection to Signal API when connection is lost

The client now attempts to reconnect to the Signal API when the connection drops, with a 1-second delay between retries. The websocket connection is now properly managed through a dedicated Connect() method.

ref #8

Co-authored-by: Mathias Fredriksson <mafredri@gmail.com>