### PR TITLE
fix(receiver): Ignore non-data messages

### DIFF
--- a/receiver/client.go
+++ b/receiver/client.go
@@ -166,14 +166,16 @@ func (c *Client) Pop() *Message {
 func (c *Client) recordMessage(msg []byte) {
 	var m Message
 	if err := json.Unmarshal(msg, &m); err != nil {
-		log.Printf("error decoding the message below: %s", err)
+		log.Printf("Error decoding the message below: %s", err)
 		log.Print(string(msg[:]))
 
 		return
 	}
 
-	// do not record typing messages
-	if m.Envelope.DataMessage == nil {
+	// Do not record receipt, typing, group update or sync messages, etc.
+	if m.Envelope.DataMessage == nil || m.Envelope.DataMessage.Message == nil {
+		log.Printf("Ignoring non-data message: %s", string(msg))
+
 		return
 	}
 


### PR DESCRIPTION
Improve message filtering and logging in Signal client

- Add logging for non-data messages that are being ignored
- Only record messages that contain actual message data
- Improve error message capitalization for consistency
- Add filtering for receipt, typing, group update and sync messages

ref #8

Co-authored-by: Mathias Fredriksson <mafredri@gmail.com>