### PR TITLE
feat(server): Repeat last message on /receive/pop

### DIFF
--- a/main.go
+++ b/main.go
@@ -19,15 +19,18 @@ func main() {
 
 func realMain() int {
 	var (
-		addr          string
-		signalAPIURL  string
-		signalAccount string
+		addr              string
+		signalAPIURL      string
+		signalAccount     string
+		repeatLastMessage bool
 	)
 
 	flag.StringVar(&addr, "addr", ":8105", "The address to listen and serve on")
 	flag.StringVar(&signalAPIURL, "signal-api-url", "",
 		"The URL of the Signal api including the scheme. e.g wss://signal-api.example.com")
 	flag.StringVar(&signalAccount, "signal-account", "", "The account number for signal")
+	flag.BoolVar(&repeatLastMessage, "repeat-last-message", false,
+		"Repeat the last message if there are no new messages (applies to /receive/pop)")
 
 	flag.Parse()
 
@@ -60,7 +63,7 @@ func realMain() int {
 		return 1
 	}
 
-	srv := server.New(sarc)
+	srv := server.New(sarc, repeatLastMessage)
 
 	server := &http.Server{
 		Addr:              addr,

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -58,7 +58,7 @@ func TestServeHTTP(t *testing.T) {
 
 			mc := &mockClient{msgs: []receiver.Message{}}
 
-			s := server.New(mc)
+			s := server.New(mc, false)
 
 			hs := httptest.NewServer(s)
 			defer hs.Close()
@@ -77,7 +77,7 @@ func TestServeHTTP(t *testing.T) {
 
 			mc := &mockClient{msgs: []receiver.Message{}}
 
-			s := server.New(mc)
+			s := server.New(mc, false)
 
 			hs := httptest.NewServer(s)
 			defer hs.Close()
@@ -108,7 +108,7 @@ func TestServeHTTP(t *testing.T) {
 
 			mc := &mockClient{msgs: []receiver.Message{}}
 
-			s := server.New(mc)
+			s := server.New(mc, false)
 
 			hs := httptest.NewServer(s)
 			defer hs.Close()
@@ -153,7 +153,7 @@ func TestServeHTTP(t *testing.T) {
 
 			mc := &mockClient{msgs: []receiver.Message{}}
 
-			s := server.New(mc)
+			s := server.New(mc, false)
 
 			hs := httptest.NewServer(s)
 			defer hs.Close()
@@ -183,7 +183,7 @@ func TestServeHTTP(t *testing.T) {
 
 			mc := &mockClient{msgs: []receiver.Message{}}
 
-			s := server.New(mc)
+			s := server.New(mc, false)
 
 			hs := httptest.NewServer(s)
 			defer hs.Close()
@@ -214,7 +214,7 @@ func TestServeHTTP(t *testing.T) {
 
 			mc := &mockClient{msgs: []receiver.Message{}}
 
-			s := server.New(mc)
+			s := server.New(mc, false)
 
 			hs := httptest.NewServer(s)
 			defer hs.Close()
@@ -254,7 +254,7 @@ func TestServeHTTP(t *testing.T) {
 
 				mc := &mockClient{msgs: []receiver.Message{}}
 
-				s := server.New(mc)
+				s := server.New(mc, false)
 
 				hs := httptest.NewServer(s)
 				defer hs.Close()
@@ -273,7 +273,7 @@ func TestServeHTTP(t *testing.T) {
 
 				mc := &mockClient{msgs: []receiver.Message{}}
 
-				s := server.New(mc)
+				s := server.New(mc, false)
 
 				hs := httptest.NewServer(s)
 				defer hs.Close()
@@ -292,7 +292,7 @@ func TestServeHTTP(t *testing.T) {
 
 				mc := &mockClient{msgs: []receiver.Message{}}
 
-				s := server.New(mc)
+				s := server.New(mc, false)
 
 				hs := httptest.NewServer(s)
 				defer hs.Close()


### PR DESCRIPTION
Adds a new flag `repeat-last-message` that enables repeating the last received message when no new messages are available via `/receive/pop`. When enabled, the server stores the most recent message and returns it on subsequent requests if no new messages have arrived.

closes #8

Co-authored-by: Mathias Fredriksson <mafredri@gmail.com>