### PR TITLE
test(server): Speed up the server tests

### DIFF
--- a/server/server_test.go
+++ b/server/server_test.go
@@ -20,6 +20,8 @@ type mockClient struct {
 }
 
 func (mc *mockClient) ReceiveLoop() error {
+	<-(make(chan struct{})) // block forever.
+
 	return nil
 }
 


### PR DESCRIPTION
The mock ReceiveLoop was returning immediately causing the test to spin in a tight loop consuming CPU resources. By blocking forever like the real implementation, the test now runs significantly faster and more efficiently.