### PR TITLE
fix(receiver): Properly ignore non-data messages

### DIFF
--- a/pkg/receiver/client.go
+++ b/pkg/receiver/client.go
@@ -108,7 +108,7 @@ func (c *Client) recordMessage(msg []byte) {
 	}
 
 	// Do not record receipt, typing, group update or sync messages, etc.
-	if m.Envelope.DataMessage == nil || m.Envelope.DataMessage.Message == nil {
+	if !m.IsDataMessage() {
 		//nolint:zerologlint
 		if c.logger.Debug().Enabled() {
 			c.logger.

--- a/pkg/receiver/message.go
+++ b/pkg/receiver/message.go
@@ -81,3 +81,10 @@ type Attachment struct {
 	Caption         *string `json:"caption"`
 	UploadTimestamp *int64  `json:"uploadTimestamp"`
 }
+
+func (m *Message) IsDataMessage() bool {
+	return m.Envelope.DataMessage != nil &&
+		m.Envelope.ReceiptMessage == nil &&
+		m.Envelope.TypingMessage == nil &&
+		m.Envelope.SyncMessage == nil
+}


### PR DESCRIPTION
### TL;DR
Added a new `IsDataMessage()` helper method to improve message type validation.

### What changed?
- Added `IsDataMessage()` method to the `Message` struct to check if a message is a data message
- Updated `recordMessage()` to use the new helper method instead of direct nil checks
- The new method ensures a message is a data message by verifying it has DataMessage content while excluding receipt, typing, and sync messages

### How to test?
1. Send different types of messages (regular messages, typing indicators, receipts, sync messages)
2. Verify that only actual data messages are being recorded
3. Confirm that typing indicators, receipts, and sync messages are properly logged but not recorded

### Why make this change?
The previous implementation only checked for nil DataMessage and Message fields, which wasn't comprehensive enough to filter out all non-data message types. This change provides a more robust way to identify data messages while making the code more maintainable and easier to understand.