### PR TITLE
fix(serve): Add logger to context

### DIFF
--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -86,6 +86,8 @@ func serveCommand(logger zerolog.Logger) *cli.Command {
 
 func serveAction(logger zerolog.Logger) cli.ActionFunc {
 	return func(ctx context.Context, cmd *cli.Command) error {
+		ctx = logger.WithContext(ctx)
+
 		ctx, cancel := context.WithCancel(ctx)
 
 		g, ctx := errgroup.WithContext(ctx)


### PR DESCRIPTION
### TL;DR

Added logger to context in serve command

### What changed?

Added `logger.WithContext(ctx)` to the serve action function to ensure the logger is available throughout the context chain

### How to test?

1. Run the serve command
2. Verify that logging works correctly in downstream functions that access the logger from context

### Why make this change?

Ensures consistent access to the logger throughout the application by making it available via context, following Go's context-based dependency injection pattern. This enables better logging capabilities across the codebase without passing the logger explicitly through function parameters.