### PR TITLE
refactor(server): Migrate to chi router

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/kalbasit/signal-api-receiver
 go 1.23.3
 
 require (
+	github.com/go-chi/chi/v5 v5.2.0
 	github.com/gorilla/websocket v1.5.3
 	github.com/rs/zerolog v1.33.0
 	github.com/stretchr/testify v1.10.0

--- a/go.sum
+++ b/go.sum
@@ -2,6 +2,8 @@ github.com/coreos/go-systemd/v22 v22.5.0/go.mod h1:Y58oyj3AT4RCenI/lSvhwexgC+NSV
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/go-chi/chi/v5 v5.2.0 h1:Aj1EtB0qR2Rdo2dG4O94RIU35w2lvQSj6BRA4+qwFL0=
+github.com/go-chi/chi/v5 v5.2.0/go.mod h1:DslCQbL2OYiznFReuXYUmQ2hGd1aDpCnlMNITLSKoi8=
 github.com/godbus/dbus/v5 v5.0.4/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=
 github.com/gorilla/websocket v1.5.3 h1:saDtZ6Pbx/0u+bgYQ3q96pZgCzfhKXGPqt7kZ72aNNg=
 github.com/gorilla/websocket v1.5.3/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=

--- a/nix/packages/signal-api-receiver.nix
+++ b/nix/packages/signal-api-receiver.nix
@@ -35,7 +35,7 @@
 
           subPackages = [ "." ];
 
-          vendorHash = "sha256-YZ8ZWBLPqMe+gM5zVNbpQJUbeI4uC12ygNYF9lMHTm0=";
+          vendorHash = "sha256-Q/8AD0d2pNBB/uarwHq+jimDxtg+YfId9XCXprMcU3g=";
 
           doCheck = true;
 

--- a/pkg/receiver/client.go
+++ b/pkg/receiver/client.go
@@ -101,7 +101,7 @@ func (c *Client) recordMessage(msg []byte) {
 		c.logger.
 			Error().
 			Err(err).
-			Str("message", string(msg)).
+			Str("signal-message", string(msg)).
 			Msg("error decoding the message")
 
 		return

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -299,7 +299,7 @@ func TestServeHTTP(t *testing.T) {
 				resp, err := http.DefaultClient.Do(r)
 				require.NoError(t, err)
 
-				assert.Equal(t, http.StatusForbidden, resp.StatusCode)
+				assert.Equal(t, http.StatusNotFound, resp.StatusCode)
 			})
 
 			t.Run(verb+" /receive/flush", func(t *testing.T) {
@@ -318,7 +318,7 @@ func TestServeHTTP(t *testing.T) {
 				resp, err := http.DefaultClient.Do(r)
 				require.NoError(t, err)
 
-				assert.Equal(t, http.StatusForbidden, resp.StatusCode)
+				assert.Equal(t, http.StatusMethodNotAllowed, resp.StatusCode)
 			})
 
 			t.Run(verb+" /receive/pop", func(t *testing.T) {
@@ -337,7 +337,7 @@ func TestServeHTTP(t *testing.T) {
 				resp, err := http.DefaultClient.Do(r)
 				require.NoError(t, err)
 
-				assert.Equal(t, http.StatusForbidden, resp.StatusCode)
+				assert.Equal(t, http.StatusMethodNotAllowed, resp.StatusCode)
 			})
 		}
 	})


### PR DESCRIPTION
Use chi router and improve logging

- Replace custom HTTP routing with chi router and middleware
- Change message logging key from `message` to `signal-message` for clarity
- Add request logging middleware with detailed request/response information