### PR TITLE
build: Disable CGO in signal-api-receiver

### DIFF
--- a/nix/packages/signal-api-receiver.nix
+++ b/nix/packages/signal-api-receiver.nix
@@ -29,6 +29,8 @@
             root = ../..;
           };
 
+          CGO_ENABLED = 0;
+
           ldflags = [
             "-X github.com/kalbasit/signal-api-receiver/cmd.Version=${version}"
           ];


### PR DESCRIPTION
### TL;DR

Enable static compilation of signal-api-receiver by setting CGO_ENABLED=0

### What changed?

Added `CGO_ENABLED = 0` to the build configuration in signal-api-receiver.nix to ensure the binary is statically linked.

### How to test?

1. Build the signal-api-receiver package
2. Verify the binary is statically linked using `ldd`
3. Confirm the binary can be executed on systems without shared libraries

### Why make this change?

Static compilation ensures the binary can run on minimal container images and systems without requiring additional shared libraries, improving portability and reducing deployment dependencies.