### PR TITLE
fix(receiver): Log Signal messages only when debugging

### DIFF
--- a/pkg/receiver/client.go
+++ b/pkg/receiver/client.go
@@ -109,10 +109,17 @@ func (c *Client) recordMessage(msg []byte) {
 
 	// Do not record receipt, typing, group update or sync messages, etc.
 	if m.Envelope.DataMessage == nil || m.Envelope.DataMessage.Message == nil {
-		c.logger.
-			Info().
-			Str("message", string(msg)).
-			Msg("ignoring non-data message")
+		//nolint:zerologlint
+		if c.logger.Debug().Enabled() {
+			c.logger.
+				Debug().
+				Interface("signal-message", m).
+				Msg("ignoring non-data message")
+		} else {
+			c.logger.
+				Info().
+				Msg("ignoring non-data message")
+		}
 
 		return
 	}
@@ -121,8 +128,15 @@ func (c *Client) recordMessage(msg []byte) {
 	c.messages = append(c.messages, m)
 	c.mu.Unlock()
 
-	c.logger.
-		Info().
-		Str("message", string(msg)).
-		Msg("a signal message was successfully recorded")
+	//nolint:zerologlint
+	if c.logger.Debug().Enabled() {
+		c.logger.
+			Debug().
+			Interface("signal-message", m).
+			Msg("a signal message was successfully recorded")
+	} else {
+		c.logger.
+			Info().
+			Msg("a signal message was successfully recorded")
+	}
 }


### PR DESCRIPTION
### TL;DR
Improved logging behavior for Signal message handling to prevent sensitive data exposure in production logs.

### What changed?
- Modified logging to only show detailed message content at DEBUG level
- Replaced raw message string logging with structured signal message interface
- Added conditional debug logging checks to prevent unnecessary string formatting
- Simplified INFO level logs to only show status messages without sensitive data

### How to test?
1. Run the application with DEBUG level logging enabled to verify detailed message content is visible
2. Run the application with INFO level logging to confirm sensitive message content is not exposed
3. Send various Signal messages and verify appropriate logging behavior at both levels

### Why make this change?
To enhance security by preventing sensitive message content from appearing in production logs while maintaining detailed logging capability for debugging purposes. This change helps protect user privacy while still providing necessary information for troubleshooting.