### PR TITLE
feat(receiver): Add message type enum and logging

### DIFF
--- a/pkg/receiver/client.go
+++ b/pkg/receiver/client.go
@@ -113,13 +113,13 @@ func (c *Client) recordMessage(msg []byte) {
 		if c.logger.Debug().Enabled() {
 			c.logger.
 				Debug().
-				Strs("message-types", messageTypesToStrings(m.MessageTypes())).
+				Strs("message-types", m.MessageTypesStrings()).
 				Interface("message-content", m).
 				Msg("ignoring non-data message")
 		} else {
 			c.logger.
 				Info().
-				Strs("message-types", messageTypesToStrings(m.MessageTypes())).
+				Strs("message-types", m.MessageTypesStrings()).
 				Msg("ignoring non-data message")
 		}
 
@@ -134,13 +134,13 @@ func (c *Client) recordMessage(msg []byte) {
 	if c.logger.Debug().Enabled() {
 		c.logger.
 			Debug().
-			Strs("message-types", messageTypesToStrings(m.MessageTypes())).
+			Strs("message-types", m.MessageTypesStrings()).
 			Interface("message-content", m).
 			Msg("a signal message was successfully recorded")
 	} else {
 		c.logger.
 			Info().
-			Strs("message-types", messageTypesToStrings(m.MessageTypes())).
+			Strs("message-types", m.MessageTypesStrings()).
 			Msg("a signal message was successfully recorded")
 	}
 }

--- a/pkg/receiver/client.go
+++ b/pkg/receiver/client.go
@@ -113,13 +113,13 @@ func (c *Client) recordMessage(msg []byte) {
 		if c.logger.Debug().Enabled() {
 			c.logger.
 				Debug().
-				Str("message-type", m.MessageType().String()).
+				Strs("message-types", messageTypesToStrings(m.MessageTypes())).
 				Interface("message-content", m).
 				Msg("ignoring non-data message")
 		} else {
 			c.logger.
 				Info().
-				Str("message-type", m.MessageType().String()).
+				Strs("message-types", messageTypesToStrings(m.MessageTypes())).
 				Msg("ignoring non-data message")
 		}
 
@@ -134,13 +134,13 @@ func (c *Client) recordMessage(msg []byte) {
 	if c.logger.Debug().Enabled() {
 		c.logger.
 			Debug().
-			Str("message-type", m.MessageType().String()).
+			Strs("message-types", messageTypesToStrings(m.MessageTypes())).
 			Interface("message-content", m).
 			Msg("a signal message was successfully recorded")
 	} else {
 		c.logger.
 			Info().
-			Str("message-type", m.MessageType().String()).
+			Strs("message-types", messageTypesToStrings(m.MessageTypes())).
 			Msg("a signal message was successfully recorded")
 	}
 }

--- a/pkg/receiver/client.go
+++ b/pkg/receiver/client.go
@@ -113,11 +113,13 @@ func (c *Client) recordMessage(msg []byte) {
 		if c.logger.Debug().Enabled() {
 			c.logger.
 				Debug().
-				Interface("signal-message", m).
+				Str("message-type", m.MessageType().String()).
+				Interface("message-content", m).
 				Msg("ignoring non-data message")
 		} else {
 			c.logger.
 				Info().
+				Str("message-type", m.MessageType().String()).
 				Msg("ignoring non-data message")
 		}
 
@@ -132,11 +134,13 @@ func (c *Client) recordMessage(msg []byte) {
 	if c.logger.Debug().Enabled() {
 		c.logger.
 			Debug().
-			Interface("signal-message", m).
+			Str("message-type", m.MessageType().String()).
+			Interface("message-content", m).
 			Msg("a signal message was successfully recorded")
 	} else {
 		c.logger.
 			Info().
+			Str("message-type", m.MessageType().String()).
 			Msg("a signal message was successfully recorded")
 	}
 }

--- a/pkg/receiver/message.go
+++ b/pkg/receiver/message.go
@@ -1,21 +1,76 @@
 package receiver
 
+import (
+	"errors"
+	"fmt"
+)
+
+// ErrMessageTypeUnknown is returned if message type (string) is not known.
+var ErrMessageTypeUnknown = errors.New("message type is unknown")
+
+// MessageType represents a type of a message.
+type MessageType uint8
+
+const (
+	MessageTypeUnknown MessageType = iota
+	MessageTypeReceiptMessage
+	MessageTypeTypingMessage
+	MessageTypeDataMessage
+	MessageTypeSyncMessage
+)
+
+// String returns the string representation of a message type.
+func (mt MessageType) String() string {
+	switch mt {
+	case MessageTypeReceiptMessage:
+		return "receipt"
+	case MessageTypeTypingMessage:
+		return "typing"
+	case MessageTypeDataMessage:
+		return "data"
+	case MessageTypeSyncMessage:
+		return "sync"
+	case MessageTypeUnknown:
+		fallthrough
+	default:
+		panic(fmt.Sprintf("unknown message type %d", mt))
+	}
+}
+
+// ParseMessageType parses a message type given its representation as a string.
+func ParseMessageType(mt string) (MessageType, error) {
+	switch mt {
+	case "receipt":
+		return MessageTypeReceiptMessage, nil
+	case "typing":
+		return MessageTypeTypingMessage, nil
+	case "data":
+		return MessageTypeDataMessage, nil
+	case "sync":
+		return MessageTypeSyncMessage, nil
+	default:
+		return MessageTypeUnknown, ErrMessageTypeUnknown
+	}
+}
+
 // Message defines the message structure received from the Signal API.
 type Message struct {
-	Envelope struct {
-		Source         string          `json:"source"`
-		SourceNumber   string          `json:"sourceNumber"`
-		SourceUUID     string          `json:"sourceUuid"`
-		SourceName     string          `json:"sourceName"`
-		SourceDevice   int             `json:"sourceDevice"`
-		Timestamp      int64           `json:"timestamp"`
-		ReceiptMessage *ReceiptMessage `json:"receiptMessage,omitempty"`
-		TypingMessage  *TypingMessage  `json:"typingMessage,omitempty"`
-		DataMessage    *DataMessage    `json:"dataMessage,omitempty"`
-		SyncMessage    *struct{}       `json:"syncMessage,omitempty"`
-	} `json:"envelope"`
+	Account  string   `json:"account"`
+	Envelope Envelope `json:"envelope"`
+}
 
-	Account string `json:"account"`
+// Envelope represents a message envelope.
+type Envelope struct {
+	Source         string          `json:"source"`
+	SourceNumber   string          `json:"sourceNumber"`
+	SourceUUID     string          `json:"sourceUuid"`
+	SourceName     string          `json:"sourceName"`
+	SourceDevice   int             `json:"sourceDevice"`
+	Timestamp      int64           `json:"timestamp"`
+	ReceiptMessage *ReceiptMessage `json:"receiptMessage,omitempty"`
+	TypingMessage  *TypingMessage  `json:"typingMessage,omitempty"`
+	DataMessage    *DataMessage    `json:"dataMessage,omitempty"`
+	SyncMessage    *struct{}       `json:"syncMessage,omitempty"`
 }
 
 // ReceiptMessage represents a receipt message.
@@ -80,4 +135,25 @@ type Attachment struct {
 	Height          *int    `json:"height"`
 	Caption         *string `json:"caption"`
 	UploadTimestamp *int64  `json:"uploadTimestamp"`
+}
+
+// MessageType returns the type of a message.
+func (m Message) MessageType() MessageType {
+	if m.Envelope.ReceiptMessage != nil {
+		return MessageTypeReceiptMessage
+	}
+
+	if m.Envelope.TypingMessage != nil {
+		return MessageTypeTypingMessage
+	}
+
+	if m.Envelope.DataMessage != nil {
+		return MessageTypeDataMessage
+	}
+
+	if m.Envelope.SyncMessage != nil {
+		return MessageTypeSyncMessage
+	}
+
+	return MessageTypeUnknown
 }

--- a/pkg/receiver/message.go
+++ b/pkg/receiver/message.go
@@ -79,16 +79,6 @@ func ParseMessageType(mt string) (MessageType, error) {
 	}
 }
 
-func messageTypesToStrings(mts []MessageType) []string {
-	ss := make([]string, 0, len(mts))
-
-	for _, mt := range mts {
-		ss = append(ss, mt.String())
-	}
-
-	return ss
-}
-
 // Message defines the message structure received from the Signal API.
 type Message struct {
 	Account  string   `json:"account"`
@@ -198,4 +188,17 @@ func (m Message) MessageTypes() []MessageType {
 	}
 
 	return mts
+}
+
+// MessageTypes returns the types of a message encoded as a string.
+func (m Message) MessageTypesStrings() []string {
+	mts := m.MessageTypes()
+
+	ss := make([]string, 0, len(mts))
+
+	for _, mt := range mts {
+		ss = append(ss, mt.String())
+	}
+
+	return ss
 }

--- a/pkg/receiver/message.go
+++ b/pkg/receiver/message.go
@@ -19,6 +19,16 @@ const (
 	MessageTypeSyncMessage
 )
 
+// AllMessageTypes returns all valid message types.
+func AllMessageTypes() []MessageType {
+	return []MessageType{
+		MessageTypeReceiptMessage,
+		MessageTypeTypingMessage,
+		MessageTypeDataMessage,
+		MessageTypeSyncMessage,
+	}
+}
+
 // String returns the string representation of a message type.
 func (mt MessageType) String() string {
 	switch mt {

--- a/pkg/receiver/message_test.go
+++ b/pkg/receiver/message_test.go
@@ -1,0 +1,61 @@
+package receiver_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/kalbasit/signal-api-receiver/pkg/receiver"
+)
+
+func TestMessageType(t *testing.T) {
+	t.Parallel()
+
+	t.Run("MessageTypeReceiptMessage", func(t *testing.T) {
+		t.Parallel()
+
+		m := receiver.Message{
+			Envelope: receiver.Envelope{
+				ReceiptMessage: &receiver.ReceiptMessage{},
+			},
+		}
+
+		assert.Equal(t, receiver.MessageTypeReceiptMessage, m.MessageType())
+	})
+
+	t.Run("MessageTypeTypingMessage", func(t *testing.T) {
+		t.Parallel()
+
+		m := receiver.Message{
+			Envelope: receiver.Envelope{
+				TypingMessage: &receiver.TypingMessage{},
+			},
+		}
+
+		assert.Equal(t, receiver.MessageTypeTypingMessage, m.MessageType())
+	})
+
+	t.Run("MessageTypeDataMessage", func(t *testing.T) {
+		t.Parallel()
+
+		m := receiver.Message{
+			Envelope: receiver.Envelope{
+				DataMessage: &receiver.DataMessage{},
+			},
+		}
+
+		assert.Equal(t, receiver.MessageTypeDataMessage, m.MessageType())
+	})
+
+	t.Run("MessageTypeSyncMessage", func(t *testing.T) {
+		t.Parallel()
+
+		m := receiver.Message{
+			Envelope: receiver.Envelope{
+				SyncMessage: &struct{}{},
+			},
+		}
+
+		assert.Equal(t, receiver.MessageTypeSyncMessage, m.MessageType())
+	})
+}

--- a/pkg/receiver/message_test.go
+++ b/pkg/receiver/message_test.go
@@ -20,7 +20,9 @@ func TestMessageType(t *testing.T) {
 			},
 		}
 
-		assert.Equal(t, receiver.MessageTypeReceiptMessage, m.MessageType())
+		assert.Equal(t,
+			[]receiver.MessageType{receiver.MessageTypeReceipt},
+			m.MessageTypes())
 	})
 
 	t.Run("MessageTypeTypingMessage", func(t *testing.T) {
@@ -32,10 +34,12 @@ func TestMessageType(t *testing.T) {
 			},
 		}
 
-		assert.Equal(t, receiver.MessageTypeTypingMessage, m.MessageType())
+		assert.Equal(t,
+			[]receiver.MessageType{receiver.MessageTypeTyping},
+			m.MessageTypes())
 	})
 
-	t.Run("MessageTypeDataMessage", func(t *testing.T) {
+	t.Run("MessageTypeData", func(t *testing.T) {
 		t.Parallel()
 
 		m := receiver.Message{
@@ -44,7 +48,28 @@ func TestMessageType(t *testing.T) {
 			},
 		}
 
-		assert.Equal(t, receiver.MessageTypeDataMessage, m.MessageType())
+		assert.Equal(t,
+			[]receiver.MessageType{receiver.MessageTypeData},
+			m.MessageTypes())
+	})
+
+	t.Run("MessageTypeDataMessage", func(t *testing.T) {
+		t.Parallel()
+
+		msg := "test"
+
+		m := receiver.Message{
+			Envelope: receiver.Envelope{
+				DataMessage: &receiver.DataMessage{Message: &msg},
+			},
+		}
+
+		assert.Equal(t,
+			[]receiver.MessageType{
+				receiver.MessageTypeData,
+				receiver.MessageTypeDataMessage,
+			},
+			m.MessageTypes())
 	})
 
 	t.Run("MessageTypeSyncMessage", func(t *testing.T) {
@@ -56,6 +81,8 @@ func TestMessageType(t *testing.T) {
 			},
 		}
 
-		assert.Equal(t, receiver.MessageTypeSyncMessage, m.MessageType())
+		assert.Equal(t,
+			[]receiver.MessageType{receiver.MessageTypeSync},
+			m.MessageTypes())
 	})
 }


### PR DESCRIPTION
Add message type

- Add `MessageType` enum to represent different message types (receipt, typing, data, data-message, sync)
- Add helper functions to parse and convert message types to strings
- Extract `Envelope` into its own type
- Add `MessageType()` method to determine the type of a message

Log the message type

- Include message type in debug and info log entries
- Improve log readability by separating message type from content