### PR TITLE
feat: Add message type filtering via CLI flag

### DIFF
--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -35,6 +35,26 @@ func serveCommand() *cli.Command {
 		Usage:   "start the signal-api-receiver HTTP server",
 		Action:  serveAction(),
 		Flags: []cli.Flag{
+			&cli.StringSliceFlag{
+				Name: "record-message-type",
+				Usage: fmt.Sprintf(
+					"Which message types to record? Valid message types: %v",
+					receiver.AllMessageTypes(),
+				),
+				Value: []string{
+					receiver.MessageTypeDataMessage.String(),
+				},
+				Validator: func(mts []string) error {
+					for _, mt := range mts {
+						_, err := receiver.ParseMessageType(mt)
+						if err != nil {
+							return fmt.Errorf("could not parse message type %q: %w", mt, err)
+						}
+					}
+
+					return nil
+				},
+			},
 			&cli.BoolFlag{
 				Name:    "repeat-last-message",
 				Usage:   "Repeat the last message if there are no new messages (applies to /receive/pop)",

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -141,7 +141,7 @@ func serveAction() cli.ActionFunc {
 			Str("signal-api-url", uri.String()).
 			Msg("the fully qualified signal-api URL was computed")
 
-		sarc, err := receiver.New(ctx, uri)
+		sarc, err := receiver.New(ctx, uri, cmd.StringSlice("record-message-type")...)
 		if err != nil {
 			return fmt.Errorf("error creating a new receiver: %w", err)
 		}

--- a/pkg/receiver/client.go
+++ b/pkg/receiver/client.go
@@ -28,7 +28,7 @@ type Client struct {
 // New creates a new Signal API client and returns it.
 // An error is returned if a websocket fails to open with the Signal's API
 // /v1/receive.
-func New(ctx context.Context, uri *url.URL, messageTypes []string) (*Client, error) {
+func New(ctx context.Context, uri *url.URL, messageTypes ...string) (*Client, error) {
 	c := &Client{
 		uri:                 uri,
 		logger:              *zerolog.Ctx(ctx),

--- a/pkg/receiver/client.go
+++ b/pkg/receiver/client.go
@@ -127,7 +127,7 @@ func (c *Client) recordMessage(msg []byte) {
 		return
 	}
 
-	if !c.recordedMessageTypes[m.MessageType()] {
+	if !c.shouldRecordMessage(m) {
 		//nolint:zerologlint
 		if c.logger.Debug().Enabled() {
 			c.logger.
@@ -162,4 +162,14 @@ func (c *Client) recordMessage(msg []byte) {
 			Strs("message-types", m.MessageTypesStrings()).
 			Msg("a signal message was successfully recorded")
 	}
+}
+
+func (c *Client) shouldRecordMessage(m Message) bool {
+	for _, mt := range m.MessageTypes() {
+		if c.recordedMessageTypes[mt] {
+			return true
+		}
+	}
+
+	return false
 }

--- a/pkg/receiver/client.go
+++ b/pkg/receiver/client.go
@@ -19,6 +19,8 @@ type Client struct {
 
 	logger zerolog.Logger
 
+	allowedMessageTypes map[MessageType]bool
+
 	mu       sync.Mutex
 	messages []Message
 }
@@ -26,8 +28,21 @@ type Client struct {
 // New creates a new Signal API client and returns it.
 // An error is returned if a websocket fails to open with the Signal's API
 // /v1/receive.
-func New(ctx context.Context, uri *url.URL) (*Client, error) {
-	c := &Client{uri: uri, logger: *zerolog.Ctx(ctx)}
+func New(ctx context.Context, uri *url.URL, messageTypes []string) (*Client, error) {
+	c := &Client{
+		uri:                 uri,
+		logger:              *zerolog.Ctx(ctx),
+		allowedMessageTypes: make(map[MessageType]bool),
+	}
+
+	for _, mts := range messageTypes {
+		mt, err := ParseMessageType(mts)
+		if err != nil {
+			return nil, fmt.Errorf("could not parse message type %q: %w", mts, err)
+		}
+
+		c.allowedMessageTypes[mt] = true
+	}
 
 	return c, c.Connect()
 }
@@ -107,8 +122,7 @@ func (c *Client) recordMessage(msg []byte) {
 		return
 	}
 
-	// Do not record receipt, typing, group update or sync messages, etc.
-	if m.Envelope.DataMessage == nil || m.Envelope.DataMessage.Message == nil {
+	if !c.allowedMessageTypes[m.MessageType()] {
 		//nolint:zerologlint
 		if c.logger.Debug().Enabled() {
 			c.logger.


### PR DESCRIPTION
Adds configurable message type recording

Previously, the signal-api-receiver only recorded data messages. This change adds a new flag `--record-message-type` that allows users to specify which message types to record (e.g. data (with or without message), data messages, typing indicators, receipts).

The flag accepts multiple values and validates them against known message types. The receiver now checks incoming messages against the configured types before recording them.

The receive loop now logs which message types are being recorded when it starts up.