### PR TITLE
docs: Update CLI flag format in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,10 +55,10 @@ specific use case.
 
 To run `signal-api-receiver`, you need to provide the following command-line flags:
 
-- `-signal-account string`: The account number for Signal.
-- `-signal-api-url string`: The URL of the Signal API, including the scheme (e.g., `wss://signal-api.example.com`).
+- `--signal-account string`: The account number for Signal.
+- `--signal-api-url string`: The URL of the Signal API, including the scheme (e.g., `wss://signal-api.example.com`).
 
-By default, the server starts on `:8105`. You can change this using the `-addr` flag (e.g., `-addr :8080`).
+By default, the server starts on `:8105`. You can change this using the `--server-addr` flag (e.g., `--server-addr :8080`).
 
 ### Kubernetes Deployment Example
 


### PR DESCRIPTION
### TL;DR
Updated command-line flag syntax in README.md from single hyphen to double hyphen format and renamed the address flag.

### What changed?
- Changed `-signal-account` to `--signal-account`
- Changed `-signal-api-url` to `--signal-api-url`
- Renamed `-addr` flag to `--server-addr`

### How to test?
1. Review the README.md file
2. Verify that all command-line flags use the double hyphen format
3. Confirm the server address flag is now referenced as `--server-addr`

### Why make this change?
To maintain consistency with modern CLI flag conventions that use double hyphens for full-word flags. The server address flag was renamed to be more descriptive and follow the same naming pattern as other flags in the application.