### PR TITLE
docs: Expand Kubernetes deployment examples in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,10 @@ By default, the server starts on `:8105`. You can change this using the `--serve
 
 ### Kubernetes Deployment Example
 
-Here's an example of how to deploy `signal-api-receiver` on Kubernetes:
+Here's an example of how to deploy `signal-api-receiver` on Kubernetes alongside existing `signal-cli-rest-api` deployment that is not shown here:
+
+<details>
+<summary>Deployment</summary>
 
 ```yaml
 apiVersion: apps/v1
@@ -90,7 +93,7 @@ spec:
           args:
             - /bin/signal-api-receiver
             - serve
-            - --signal-api-url=wss://signal-api.example.com
+            - --signal-api-url=ws://signal-api.ns.svc:8080
             - --signal-account=+19876543210
           ports:
             - containerPort: 8105
@@ -108,6 +111,66 @@ spec:
             initialDelaySeconds: 5
             periodSeconds: 10
 ```
+
+</details>
+
+<details>
+<summary>Service</summary>
+
+```yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: signal-api-receiver
+  labels:
+    app: signal-receiver
+    tier: api
+spec:
+  type: ClusterIP
+  ports:
+    - name: receiver-web
+      port: 8105
+  selector:
+    app: signal-receiver
+    tier: api
+```
+
+</details>
+
+<details>
+<summary>IngressRoute</summary>
+
+**NOTE**: This IngressRoute has been tested with Traefik.
+
+```yaml
+apiVersion: traefik.containo.us/v1alpha1
+kind: IngressRoute
+metadata:
+  name: signal-api
+spec:
+  entryPoints:
+    - websecure
+  routes:
+    - kind: Rule
+      match: Host(`signal-api.example.com`)
+      priority: 10
+      middlewares:
+        - name: hsts-header
+          namespace: kube-system
+      services:
+        - name: signal-api
+          port: http-web
+    - kind: Rule
+      match: Host(`signal-api.example.com`) && Path(`/receive`)
+      priority: 20
+      services:
+        - name: signal-api-receiver
+          port: receiver-web
+  tls:
+    secretName: signal-api-tls
+```
+
+</details>
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -138,9 +138,7 @@ spec:
 </details>
 
 <details>
-<summary>IngressRoute</summary>
-
-**NOTE**: This IngressRoute has been tested with Traefik.
+<summary>Traefik IngressRoute</summary>
 
 ```yaml
 apiVersion: traefik.containo.us/v1alpha1
@@ -149,17 +147,17 @@ metadata:
   name: signal-api
 spec:
   entryPoints:
+    - web
     - websecure
   routes:
+    # This rule is for existing signal-cli-rest-api service that is not shown here.
     - kind: Rule
       match: Host(`signal-api.example.com`)
       priority: 10
-      middlewares:
-        - name: hsts-header
-          namespace: kube-system
       services:
         - name: signal-api
           port: http-web
+    # The new rule for signal-api-receiver.
     - kind: Rule
       match: Host(`signal-api.example.com`) && Path(`/receive`)
       priority: 20


### PR DESCRIPTION
### TL;DR
Enhanced Kubernetes deployment documentation with detailed examples and configurations

### What changed?
- Added collapsible sections for Deployment, Service, and IngressRoute configurations
- Updated the signal-api-url to use internal Kubernetes service DNS
- Added a complete Service definition for the signal-api-receiver
- Included a Traefik IngressRoute configuration example with priority-based routing

### How to test?
1. Apply the provided Kubernetes manifests in your cluster
2. Verify the service is accessible internally at `signal-api-receiver.ns.svc:8105`
3. Confirm the Traefik IngressRoute properly routes traffic to both services
4. Test the `/receive` endpoint through the configured domain

### Why make this change?
To provide comprehensive deployment guidance for users setting up the signal-api-receiver alongside existing signal-cli-rest-api installations in Kubernetes environments, particularly focusing on proper service discovery and ingress configuration.