### PR TITLE
feat(docker): Add multi-arch image support

### DIFF
--- a/.github/actions/docker/action.yml
+++ b/.github/actions/docker/action.yml
@@ -1,6 +1,9 @@
 name: Build and push Docker images
 description: "Build and push Docker images"
 inputs:
+  system:
+    description: "The system for which to build the docker images for"
+    default: "x86_64-linux"
   images:
     description: "List of Docker images to use as base name for tags"
     required: false
@@ -34,14 +37,21 @@ runs:
       with:
         username: ${{ inputs.username }}
         password: ${{ inputs.password }}
+    - name: Install required cross-system tool
+      if: "${{ inputs.system != 'x86_64-linux' }}"
+      run: sudo apt-get install -y qemu-user-static
+      shell: bash
     - uses: DeterminateSystems/nix-installer-action@v16
+      with:
+        extra-conf: |
+          extra-platforms = ${{ inputs.system }}
     - uses: DeterminateSystems/magic-nix-cache-action@v8
     - name: Build the docker image pusher
       shell: bash
       env:
         RELEASE_VERSION: ${{ github.ref_name }}
       run: |
-        nix build -L --impure .#push-docker-image
+        nix build -L --impure .#packages.${{ inputs.system }}.push-docker-image
     - name: Push the docker image
       if: ${{ inputs.push }}
       env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,11 +14,15 @@ jobs:
       - uses: DeterminateSystems/flake-checker-action@main
       - run: nix flake check -L --all-systems
   docker:
+    strategy:
+      matrix:
+        system: ["x86_64-linux", "aarch64-linux"]
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/docker
         with:
+          system: ${{ matrix.system }}
           images: kalbasit/signal-api-receiver
           username: ${{ vars.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -16,12 +16,16 @@ jobs:
       - uses: DeterminateSystems/flake-checker-action@main
       - run: nix flake check -L --all-systems
   docker:
+    strategy:
+      matrix:
+        system: ["x86_64-linux", "aarch64-linux"]
     runs-on: ubuntu-24.04
     needs: flake-check
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/docker
         with:
+          system: ${{ matrix.system }}
           images: kalbasit/signal-api-receiver
           username: ${{ vars.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}

--- a/.github/workflows/releases.yml
+++ b/.github/workflows/releases.yml
@@ -16,12 +16,16 @@ jobs:
       - uses: DeterminateSystems/flake-checker-action@main
       - run: nix flake check -L --all-systems
   docker:
+    strategy:
+      matrix:
+        system: ["x86_64-linux", "aarch64-linux"]
     runs-on: ubuntu-24.04
     needs: flake-check
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/docker
         with:
+          system: ${{ matrix.system }}
           images: kalbasit/signal-api-receiver
           username: ${{ vars.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}


### PR DESCRIPTION
### TL;DR

Added multi-architecture Docker image builds for both x86_64 and aarch64 Linux platforms.

### What changed?

- Added system input parameter to Docker build action to specify target architecture
- Implemented matrix builds for x86_64-linux and aarch64-linux in CI, Docker, and release workflows
- Added QEMU user static installation for cross-architecture builds
- Configured Nix system parameter for cross-compilation
- Removed Darwin systems from supported platforms list

### How to test?

1. Run the Docker workflow manually
2. Verify that images are built for both architectures:
   ```bash
   docker pull kalbasit/signal-api-receiver:pr-42
   docker inspect kalbasit/signal-api-receiver:pr-42
   ```
3. Confirm both amd64 and arm64 variants are available in the manifest

### Why make this change?

To support running the signal-api-receiver container on ARM-based systems like Raspberry Pi or AWS Graviton instances, while maintaining compatibility with x86_64 systems. This broadens the deployment options and improves accessibility for users on different hardware architectures.