### PR TITLE
build: Remove Darwin system targets

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -34,8 +34,6 @@
       systems = [
         "x86_64-linux"
         "aarch64-linux"
-        "aarch64-darwin"
-        "x86_64-darwin"
       ];
     };
 }


### PR DESCRIPTION
### TL;DR
Removed Darwin system support from flake.nix

### What changed?
Removed `aarch64-darwin` and `x86_64-darwin` from the supported systems list in flake.nix, leaving only Linux systems (`x86_64-linux` and `aarch64-linux`).

### How to test?
1. Attempt to build the flake on a Linux system (should succeed)
2. Attempt to build the flake on a Darwin/macOS system (should fail)

### Why make this change?
This change focuses development efforts on Linux platforms, simplifying the maintenance burden by removing Darwin support. This allows for more targeted development and testing on Linux-specific features and functionality.