### PR TITLE
ci: Add -L flag and --all-systems to nix commands

### DIFF
--- a/.github/actions/docker/action.yml
+++ b/.github/actions/docker/action.yml
@@ -41,7 +41,7 @@ runs:
       env:
         RELEASE_VERSION: ${{ github.ref_name }}
       run: |
-        nix build --impure .#push-docker-image
+        nix build -L --impure .#push-docker-image
     - name: Push the docker image
       if: ${{ inputs.push }}
       env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
       - uses: DeterminateSystems/nix-installer-action@v16
       - uses: DeterminateSystems/magic-nix-cache-action@v8
       - uses: DeterminateSystems/flake-checker-action@main
-      - run: nix flake check
+      - run: nix flake check -L --all-systems
   docker:
     runs-on: ubuntu-24.04
     steps:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: DeterminateSystems/nix-installer-action@v16
       - uses: DeterminateSystems/magic-nix-cache-action@v8
       - uses: DeterminateSystems/flake-checker-action@main
-      - run: nix flake check
+      - run: nix flake check -L --all-systems
   docker:
     runs-on: ubuntu-24.04
     needs: flake-check

--- a/.github/workflows/releases.yml
+++ b/.github/workflows/releases.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: DeterminateSystems/nix-installer-action@v16
       - uses: DeterminateSystems/magic-nix-cache-action@v8
       - uses: DeterminateSystems/flake-checker-action@main
-      - run: nix flake check
+      - run: nix flake check -L --all-systems
   docker:
     runs-on: ubuntu-24.04
     needs: flake-check


### PR DESCRIPTION
### TL;DR

Added verbose logging flags to Nix commands in GitHub Actions workflows

### What changed?

- Added `-L` flag to `nix build` command in docker action
- Added `-L --all-systems` flags to `nix flake check` commands across CI, Docker, and Release workflows

### How to test?

1. Run a GitHub Actions workflow
2. Verify that Nix commands now show more detailed output in the logs
3. Confirm that flake checks run across all systems

### Why make this change?

The addition of verbose logging flags improves debugging capabilities by providing more detailed output during builds and flake checks. This makes it easier to diagnose issues when workflows fail or behave unexpectedly.