### PR TITLE
docs: Add Docker usage and expand CLI options in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ By default, the server starts on `:8105`. You can change this using the `--serve
 You can see all available options by running:
 
 ```bash
-go run . serve --help
+signal-api-receiver serve --help
 ```
 
 ### Kubernetes Deployment Example

--- a/README.md
+++ b/README.md
@@ -45,11 +45,11 @@ specific use case.
 `signal-api-receiver` exposes the following API endpoints:
 
 - `GET /receive/pop`:
-  \- Returns one message at a time from the queue.
-  \- If no messages are available, it returns a `204 No Content` status.
+  - Returns one message at a time from the queue.
+  - If no messages are available, it returns a `204 No Content` status.
 - `GET /receive/flush`:
-  \- Returns all available messages as a list.
-  \- If no messages are available, it returns an empty list (`[]`).
+  - Returns all available messages as a list.
+  - If no messages are available, it returns an empty list (`[]`).
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -45,11 +45,11 @@ specific use case.
 `signal-api-receiver` exposes the following API endpoints:
 
 - `GET /receive/pop`:
-      - Returns one message at a time from the queue.
-      - If no messages are available, it returns a `204 No Content` status.
+  \- Returns one message at a time from the queue.
+  \- If no messages are available, it returns a `204 No Content` status.
 - `GET /receive/flush`:
-      - Returns all available messages as a list.
-      - If no messages are available, it returns an empty list (`[]`).
+  \- Returns all available messages as a list.
+  \- If no messages are available, it returns an empty list (`[]`).
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -217,7 +217,7 @@ spec:
 This project is licensed under the MIT License - see the [LICENSE](/LICENSE) file for details.
 
 [@bbernhard]: https://github.com/bbernhard
+[docker hub]: https://hub.docker.com/r/kalbasit/signal-api-receiver
 [exec-mode]: https://github.com/bbernhard/signal-cli-rest-api?tab=readme-ov-file#execution-modes
 [signal-cli-rest-api]: https://github.com/bbernhard/signal-cli-rest-api
 [signal_messenger]: https://www.home-assistant.io/integrations/signal_messenger/#sending-messages-to-signal-to-trigger-events
-[Docker Hub]: https://hub.docker.com/r/kalbasit/signal-api-receiver

--- a/README.md
+++ b/README.md
@@ -45,11 +45,11 @@ specific use case.
 `signal-api-receiver` exposes the following API endpoints:
 
 - `GET /receive/pop`:
-    - Returns one message at a time from the queue.
-    - If no messages are available, it returns a `204 No Content` status.
+      - Returns one message at a time from the queue.
+      - If no messages are available, it returns a `204 No Content` status.
 - `GET /receive/flush`:
-    - Returns all available messages as a list.
-    - If no messages are available, it returns an empty list (`[]`).
+      - Returns all available messages as a list.
+      - If no messages are available, it returns an empty list (`[]`).
 
 ## Usage
 
@@ -65,9 +65,9 @@ Here's an example docker run command:
 
 ```bash
 docker run -p 8105:8105 \
-  -e SIGNAL_ACCOUNT="your_signal_account" \
-  -e SIGNAL_API_URL="wss://your-signal-api-url" \
-  kalbasit/signal-api-receiver:latest
+  -e SIGNAL_ACCOUNT="your_signal_account" \
+  -e SIGNAL_API_URL="wss://your-signal-api-url" \
+  kalbasit/signal-api-receiver:latest
 ```
 
 **Explanation**:
@@ -80,10 +80,19 @@ Refer to the Docker Hub page for more information and advanced configuration opt
 
 ### Running from Source
 
-To run signal-api-receiver from source, you need to provide the following command-line flags:
+To run `signal-api-receiver` from source, you need to provide the following command-line flags:
 
-- `--signal-account string`: The account number for Signal.
-- `--signal-api-url string`: The URL of the Signal API, including the scheme (e.g., `wss://signal-api.example.com`).
+**Global Options:**
+
+- `--log-level <value>`: Sets the logging level (default: "info"). Can be set using the `$LOG_LEVEL` environment variable.
+
+**Options for the `serve` command:**
+
+- `--record-message-type <value>`: Specifies which message types to record. Valid types are: "receipt", "typing", "data", "data-message", and "sync". This flag can be repeated to record multiple types (default: "data-message").
+- `--repeat-last-message`: If enabled, repeats the last message if no new messages are available (applies to `/receive/pop`). This can be set using the `$REPEAT_LAST_MESSAGE` environment variable (default: false).
+- `--signal-account <value>`: **Required.** Specifies your Signal account number. Can be set using the `$SIGNAL_ACCOUNT` environment variable.
+- `--signal-api-url <value>`: **Required.** Specifies the URL of your Signal API, including the scheme (e.g., `wss://signal-api.example.com`). Can be set using the `$SIGNAL_API_URL` environment variable.
+- `--server-addr <value>`: Sets the address where the server will listen (default: ":8105"). Can be set using the `$SERVER_ADDR` environment variable.
 
 By default, the server starts on `:8105`. You can change this using the `--server-addr` flag (e.g., `--server-addr :8080`).
 
@@ -104,45 +113,45 @@ Here's an example of how to deploy `signal-api-receiver` on Kubernetes alongside
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: signal-api-receiver
-  labels:
-    app: signal-receiver
-    tier: api
+  name: signal-api-receiver
+  labels:
+    app: signal-receiver
+    tier: api
 spec:
-  replicas: 1
-  selector:
-    matchLabels:
-      app: signal-receiver
-      tier: api
-  template:
-    metadata:
-      labels:
-        app: signal-receiver
-        tier: api
-    spec:
-      containers:
-        - image: kalbasit/signal-receiver:latest
-          name: signal-receiver
-          args:
-            - /bin/signal-api-receiver
-            - serve
-            - --signal-api-url=ws://signal-api.ns.svc:8080
-            - --signal-account=+19876543210
-          ports:
-            - containerPort: 8105
-              name: receiver-web
-          livenessProbe:
-            httpGet:
-              path: /healthz
-              port: receiver-web
-            initialDelaySeconds: 15
-            periodSeconds: 20
-          readinessProbe:
-            httpGet:
-              path: /healthz
-              port: receiver-web
-            initialDelaySeconds: 5
-            periodSeconds: 10
+  replicas: 1
+  selector:
+    matchLabels:
+      app: signal-receiver
+      tier: api
+  template:
+    metadata:
+      labels:
+        app: signal-receiver
+        tier: api
+    spec:
+      containers:
+        - image: kalbasit/signal-receiver:latest
+          name: signal-receiver
+          args:
+            - /bin/signal-api-receiver
+            - serve
+            - --signal-api-url=ws://signal-api.ns.svc:8080
+            - --signal-account=+19876543210
+          ports:
+            - containerPort: 8105
+              name: receiver-web
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: receiver-web
+            initialDelaySeconds: 15
+            periodSeconds: 20
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: receiver-web
+            initialDelaySeconds: 5
+            periodSeconds: 10
 ```
 
 </details>
@@ -154,18 +163,18 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
-  name: signal-api-receiver
-  labels:
-    app: signal-receiver
-    tier: api
+  name: signal-api-receiver
+  labels:
+    app: signal-receiver
+    tier: api
 spec:
-  type: ClusterIP
-  ports:
-    - name: receiver-web
-      port: 8105
-  selector:
-    app: signal-receiver
-    tier: api
+  type: ClusterIP
+  ports:
+    - name: receiver-web
+      port: 8105
+  selector:
+    app: signal-receiver
+    tier: api
 ```
 
 </details>
@@ -177,28 +186,28 @@ spec:
 apiVersion: traefik.containo.us/v1alpha1
 kind: IngressRoute
 metadata:
-  name: signal-api
+  name: signal-api
 spec:
-  entryPoints:
-    - web
-    - websecure
-  routes:
-    # This rule is for existing signal-cli-rest-api service that is not shown here.
-    - kind: Rule
-      match: Host(`signal-api.example.com`)
-      priority: 10
-      services:
-        - name: signal-api
-          port: http-web
-    # The new rule for signal-api-receiver.
-    - kind: Rule
-      match: Host(`signal-api.example.com`) && Path(`/receive`)
-      priority: 20
-      services:
-        - name: signal-api-receiver
-          port: receiver-web
-  tls:
-    secretName: signal-api-tls
+  entryPoints:
+    - web
+    - websecure
+  routes:
+    # This rule is for existing signal-cli-rest-api service that is not shown here.
+    - kind: Rule
+      match: Host(`signal-api.example.com`)
+      priority: 10
+      services:
+        - name: signal-api
+          port: http-web
+    # The new rule for signal-api-receiver.
+    - kind: Rule
+      match: Host(`signal-api.example.com`) && Path(`/receive`)
+      priority: 20
+      services:
+        - name: signal-api-receiver
+          port: receiver-web
+  tls:
+    secretName: signal-api-tls
 ```
 
 </details>

--- a/README.md
+++ b/README.md
@@ -45,20 +45,53 @@ specific use case.
 `signal-api-receiver` exposes the following API endpoints:
 
 - `GET /receive/pop`:
-  - Returns one message at a time from the queue.
-  - If no messages are available, it returns a `204 No Content` status.
+    - Returns one message at a time from the queue.
+    - If no messages are available, it returns a `204 No Content` status.
 - `GET /receive/flush`:
-  - Returns all available messages as a list.
-  - If no messages are available, it returns an empty list (`[]`).
+    - Returns all available messages as a list.
+    - If no messages are available, it returns an empty list (`[]`).
 
 ## Usage
 
-To run `signal-api-receiver`, you need to provide the following command-line flags:
+### Running with Docker
+
+`signal-api-receiver` is available as a Docker image on Docker Hub. This is the recommended way to run the application.
+
+```bash
+docker pull kalbasit/signal-api-receiver:latest
+```
+
+Here's an example docker run command:
+
+```bash
+docker run -p 8105:8105 \
+  -e SIGNAL_ACCOUNT="your_signal_account" \
+  -e SIGNAL_API_URL="wss://your-signal-api-url" \
+  kalbasit/signal-api-receiver:latest
+```
+
+**Explanation**:
+
+- `-p 8105:8105`: Maps port 8105 on the host to port 8105 in the container.
+- `-e SIGNAL_ACCOUNT="your_signal_account"`: Sets the `SIGNAL_ACCOUNT` environment variable. Replace with your actual Signal account.
+- `-e SIGNAL_API_URL="wss://your-signal-api-url"`: Sets the `SIGNAL_API_URL` environment variable. Replace with the URL of your Signal API.
+
+Refer to the Docker Hub page for more information and advanced configuration options: https://hub.docker.com/r/kalbasit/signal-api-receiver
+
+### Running from Source
+
+To run signal-api-receiver from source, you need to provide the following command-line flags:
 
 - `--signal-account string`: The account number for Signal.
 - `--signal-api-url string`: The URL of the Signal API, including the scheme (e.g., `wss://signal-api.example.com`).
 
 By default, the server starts on `:8105`. You can change this using the `--server-addr` flag (e.g., `--server-addr :8080`).
+
+You can see all available options by running:
+
+```bash
+go run . serve --help
+```
 
 ### Kubernetes Deployment Example
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# signal-api-receiver
+# Signal API Receiver
 
 ## Introduction
 

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ specific use case.
 
 ### Running with Docker
 
-`signal-api-receiver` is available as a Docker image on Docker Hub. This is the recommended way to run the application.
+`signal-api-receiver` is available as a Docker image on [Docker Hub]. This is the recommended way to run the application.
 
 ```bash
 docker pull kalbasit/signal-api-receiver:latest
@@ -76,7 +76,7 @@ docker run -p 8105:8105 \
 - `-e SIGNAL_ACCOUNT="your_signal_account"`: Sets the `SIGNAL_ACCOUNT` environment variable. Replace with your actual Signal account.
 - `-e SIGNAL_API_URL="wss://your-signal-api-url"`: Sets the `SIGNAL_API_URL` environment variable. Replace with the URL of your Signal API.
 
-Refer to the Docker Hub page for more information and advanced configuration options: https://hub.docker.com/r/kalbasit/signal-api-receiver
+Refer to the [Docker Hub] page for more information.
 
 ### Running from Source
 
@@ -220,3 +220,4 @@ This project is licensed under the MIT License - see the [LICENSE](/LICENSE) fil
 [exec-mode]: https://github.com/bbernhard/signal-cli-rest-api?tab=readme-ov-file#execution-modes
 [signal-cli-rest-api]: https://github.com/bbernhard/signal-cli-rest-api
 [signal_messenger]: https://www.home-assistant.io/integrations/signal_messenger/#sending-messages-to-signal-to-trigger-events
+[Docker Hub]: https://hub.docker.com/r/kalbasit/signal-api-receiver


### PR DESCRIPTION
# Improve README

Added Docker usage instructions and expanded command-line options documentation. Includes Docker Hub link, environment variables, and detailed explanations of available flags.

# Final Changes
- Added Docker run command examples
- Documented environment variables
- Expanded command-line options with descriptions
- Added link to Docker Hub repository

closes #44