### PR TITLE
feat: Add Empty Response Handling via CLI flag

### DIFF
--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -3,7 +3,7 @@ package server
 import (
 	"context"
 	"encoding/json"
-	"fmt"
+	//"fmt"
 	"net/http"
 	"sync/atomic"
 	"time"
@@ -40,6 +40,13 @@ type client interface {
 	Pop() *receiver.Message
 	Flush() []receiver.Message
 }
+
+type NilMessage struct {
+	Account *string `json:"account"`
+	Envelope struct{} `json:"envelope"`
+}
+
+var nilMessage = NilMessage{}
 
 // New returns a new Server.
 func New(ctx context.Context, sarc client, repeatLastMessage bool) *Server {
@@ -102,7 +109,7 @@ func (s *Server) receivePop(w http.ResponseWriter, _ *http.Request) {
 	w.Header().Set(contentType, contentTypeJSON)
 
 	if msg == nil {
-		if _, err := fmt.Fprint(w, "{}"); err != nil {
+		if err := json.NewEncoder(w).Encode(&NilMessage{}); err != nil {
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 		}
 

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -3,6 +3,7 @@ package server
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"sync/atomic"
 	"time"
@@ -98,13 +99,15 @@ func (s *Server) receivePop(w http.ResponseWriter, _ *http.Request) {
 		}
 	}
 
+	w.Header().Set(contentType, contentTypeJSON)
+
 	if msg == nil {
-		w.WriteHeader(http.StatusNoContent)
+		if _, err := fmt.Fprint(w, "{}"); err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+		}
 
 		return
 	}
-
-	w.Header().Set(contentType, contentTypeJSON)
 
 	if err := json.NewEncoder(w).Encode(msg); err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -98,20 +98,19 @@ func TestServeHTTP(t *testing.T) {
 			resp, err := http.Get(hs.URL + "/receive/pop")
 			require.NoError(t, err)
 
-			want := receiver.Message{}
-
 			assert.Equal(t, http.StatusOK, resp.StatusCode)
 
 			body, err := io.ReadAll(resp.Body)
 			require.NoError(t, err)
 
-			assert.Equal(t, "{}", string(body))
-
-			var got receiver.Message
+			want := server.NilMessage{}
+			var got server.NilMessage
 
 			require.NoError(t, json.Unmarshal(body, &got))
-
 			assert.Equal(t, want, got)
+
+			assert.Nil(t, got.Account)
+			assert.Empty(t, got.Envelope)
 		})
 
 		t.Run("one message in the queue", func(t *testing.T) {
@@ -527,7 +526,15 @@ func TestRepeatLastMessage(t *testing.T) {
 				if !withRepeatFeature {
 					body, err := io.ReadAll(resp.Body)
 					require.NoError(t, err)
-					require.Equal(t, "{}", string(body))
+
+					want := server.NilMessage{}
+					var got server.NilMessage
+
+					require.NoError(t, json.Unmarshal(body, &got))
+					assert.Equal(t, want, got)
+
+					assert.Nil(t, got.Account)
+					assert.Empty(t, got.Envelope)
 
 					return
 				}


### PR DESCRIPTION
Adds a flag which changes the default response of the route `/receive/pop` if there are no messages in the queue. Instead of an empty body and the HTTP status code 204, the HTTP status code 200 (same as if there was a message in the queue) and the body ‘{}’ (empty JSON object) are now used when this flag is set.

The purpose of this is to avoid warnings being raised by Home-Assistants Rest Integration, which expects a valid JSON object in the body.