### PR TITLE
ci(docker): Move login step before build/push operations

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -53,6 +53,11 @@ jobs:
           extra-conf: |
             extra-platforms = ${{ matrix.system }}
       - uses: DeterminateSystems/magic-nix-cache-action@v8
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ inputs.username }}
+          password: ${{ secrets.password }}
       - uses: actions/checkout@v4
       - name: Build the docker image
         shell: bash
@@ -60,11 +65,6 @@ jobs:
           RELEASE_VERSION: ${{ github.ref_name }}
         run: |
           nix build -L --impure .#packages.${{ matrix.system }}.docker
-      - name: Login to Docker Hub
-        uses: docker/login-action@v3
-        with:
-          username: ${{ inputs.username }}
-          password: ${{ secrets.password }}
       - name: Build the docker image pusher
         shell: bash
         env:
@@ -81,6 +81,11 @@ jobs:
     runs-on: ubuntu-24.04
     needs: [docker-meta, docker-images]
     steps:
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ inputs.username }}
+          password: ${{ secrets.password }}
       - name: Create a multi-architecture manifest
         env:
           DOCKER_IMAGE_TAGS: ${{ needs.docker-meta.outputs.tags }}
@@ -95,11 +100,6 @@ jobs:
 
             docker manifest create $tag ${imgs[*]}
           done
-      - name: Login to Docker Hub
-        uses: docker/login-action@v3
-        with:
-          username: ${{ inputs.username }}
-          password: ${{ secrets.password }}
       - name: Push the docker image
         env:
           DOCKER_IMAGE_TAGS: ${{ needs.docker-meta.outputs.tags }}


### PR DESCRIPTION
### TL;DR

Reordered Docker Hub login steps to occur before image operations in GitHub Actions workflow.

### What changed?

Moved the Docker Hub login action to execute before image building and manifest creation steps in the workflow. This ensures authentication is completed before any Docker operations that require it.

### How to test?

1. Run the Docker workflow with valid Docker Hub credentials
2. Verify that images build and push successfully
3. Confirm multi-architecture manifest is created and pushed correctly

### Why make this change?

To prevent potential authentication issues by ensuring Docker Hub login is completed before any Docker operations begin. This is a more logical flow as authentication should be established before attempting any registry operations.