### PR TITLE
ci(docker): Remove aarch64-linux from build systems

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
   docker:
     uses: ./.github/workflows/docker.yml
     with:
-      systems: "['x86_64-linux', 'aarch64-linux']"
+      systems: "['x86_64-linux']"
       images: kalbasit/signal-api-receiver
       username: ${{ vars.DOCKERHUB_USERNAME }}
     secrets:


### PR DESCRIPTION
### TL;DR

Removed aarch64-linux from CI Docker build targets

### What changed?

Modified the CI workflow to only build Docker images for x86_64-linux architecture, removing the aarch64-linux build target.

### How to test?

1. Trigger the CI workflow
2. Verify that only x86_64-linux Docker images are being built
3. Confirm no aarch64-linux builds are running

### Why make this change?

To reduce CI execution time as it takes 4x to build on aarch64 than it does on x86_64.