### PR TITLE
Feature - Add MQTT support

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,13 @@ To run `signal-api-receiver` from source, you need to provide the following comm
 - `--signal-api-url <value>`: **Required.** Specifies the URL of your Signal API, including the scheme (e.g., `wss://signal-api.example.com`). Can be set using the `$SIGNAL_API_URL` environment variable.
 - `--server-addr <value>`: Sets the address where the server will listen (default: ":8105"). Can be set using the `$SERVER_ADDR` environment variable.
 
-By default, the server starts on `:8105`. You can change this using the `--server-addr` flag (e.g., `--server-addr :8080`).
+- `--mqtt-server <value>`: Server address to your MQTT Broker (e.g., `mqtt://broker.srv.local:1883`). Can be set using the `$MQTT_SERVER` environment variable.
+- `--mqtt-user <value>` User used for authentication . Can be set using the `$MQTT_USER` environment variable.
+- `--mqtt-password <value>` Password of the user used for authentication. Can be set using the `$MQTT_PASSWORD` environment variable. 
+- `--mqtt-client-id <value>`: A custom client-id. This should be unique. (default: `signal-api-receiver-<mac-address>`) Can be set using the `$MQTT_CLIENT_ID` environment variable.
+- `--mqtt-topic-prefix <value>`: A custom topic prefix to broadcast (default: `signal-api-receiver`). Topic resolves to `<topic-prefix>/message`. Can be set using the `$MQTT_TOPIC_PREFIX` environment variable.
+- `--mqtt-qos` Change the quality of service. Possible options are `1`, `2`, `3`. Can be set using the `MQTT_QOS` environment variable.
+
 
 You can see all available options by running:
 

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -4,15 +4,19 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net"
 	"net/http"
 	"net/url"
 	"regexp"
+	"slices"
+	"strings"
 	"time"
 
 	"github.com/rs/zerolog"
 	"github.com/urfave/cli/v3"
 	"golang.org/x/sync/errgroup"
 
+	"github.com/kalbasit/signal-api-receiver/pkg/mqtt"
 	"github.com/kalbasit/signal-api-receiver/pkg/receiver"
 	"github.com/kalbasit/signal-api-receiver/pkg/server"
 )
@@ -28,7 +32,21 @@ var (
 	accountRegex = regexp.MustCompile(`^\+[0-9]+$`)
 )
 
+func makeRandomClientId() string {
+	netInterfaces, err := net.Interfaces()
+
+	parts := []string{"signal-api-receiver"}
+
+	if err == nil {
+		parts = append(parts, strings.ReplaceAll(netInterfaces[0].HardwareAddr.String(), ":", ""))
+	}
+
+	return strings.Join(parts, "-")
+}
+
 func serveCommand() *cli.Command {
+	randomClientId := makeRandomClientId()
+
 	return &cli.Command{
 		Name:    "serve",
 		Aliases: []string{"s"},
@@ -100,6 +118,48 @@ func serveCommand() *cli.Command {
 				Sources: cli.EnvVars("SERVER_ADDR"),
 				Value:   ":8105",
 			},
+			&cli.StringFlag{
+				Name:    "mqtt-server",
+				Usage:   "MQTT Server Host and Port",
+				Sources: cli.EnvVars("MQTT_PASSWORD"),
+			},
+			&cli.StringFlag{
+				Name:    "mqtt-client-id",
+				Usage:   "MQTT Client ID",
+				Sources: cli.EnvVars("MQTT_CLIENT_ID"),
+				Value:   randomClientId,
+			},
+			&cli.StringFlag{
+				Name:    "mqtt-user",
+				Usage:   "MQTT Username",
+				Sources: cli.EnvVars("MQTT_USER"),
+			},
+			&cli.StringFlag{
+				Name:    "mqtt-password",
+				Usage:   "MQTT Password",
+				Sources: cli.EnvVars("MQTT_PASSWORD"),
+			},
+			&cli.StringFlag{
+				Name:    "mqtt-topic-prefix",
+				Usage:   "MQTT Topic Prefix. {topic-prefix}/message",
+				Sources: cli.EnvVars("MQTT_TOPIC_PREFIX"),
+				Value:   "signal-api-receiver",
+			},
+			&cli.IntFlag{
+				Name:    "mqtt-qos",
+				Usage:   "MQTT Quality of Service value",
+				Sources: cli.EnvVars("MQTT_QOS"),
+				Value:   1,
+				Validator: func(q int64) error {
+					allowedValues := []int64{1, 2, 3}
+
+					if !slices.Contains(allowedValues, q) {
+						return fmt.Errorf("cannot parse qos %q", q)
+					}
+
+					return nil
+				},
+			},
 		},
 	}
 }
@@ -144,6 +204,22 @@ func serveAction() cli.ActionFunc {
 		sarc, err := receiver.New(ctx, uri, cmd.StringSlice("record-message-type")...)
 		if err != nil {
 			return fmt.Errorf("error creating a new receiver: %w", err)
+		}
+
+		if cmd.IsSet("mqtt-server") {
+			err := mqtt.Init(
+				ctx,
+				cmd.String("mqtt-server"),
+				cmd.String("mqtt-client-id"),
+				cmd.String("mqtt-user"),
+				cmd.String("mqtt-password"),
+				cmd.String("mqtt-topic-prefix"),
+				cmd.Int("mqtt-qos"),
+			)
+
+			if err != nil {
+				return fmt.Errorf("error initializing mqtt: %w", err)
+			}
 		}
 
 		srv := server.New(ctx, sarc, cmd.Bool("repeat-last-message"))

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/kalbasit/signal-api-receiver
 go 1.23.3
 
 require (
+	github.com/eclipse/paho.golang v0.22.0
 	github.com/go-chi/chi/v5 v5.2.1
 	github.com/gorilla/websocket v1.5.3
 	github.com/rs/zerolog v1.33.0
@@ -15,10 +16,10 @@ require (
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
-	github.com/kr/text v0.2.0 // indirect
 	github.com/mattn/go-colorable v0.1.13 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
+	golang.org/x/net v0.27.0 // indirect
 	golang.org/x/sys v0.30.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1,12 +1,15 @@
 github.com/coreos/go-systemd/v22 v22.5.0/go.mod h1:Y58oyj3AT4RCenI/lSvhwexgC+NSVTIJ3seZv2GcEnc=
-github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/eclipse/paho.golang v0.22.0 h1:JhhUngr8TBlyUZDZw/L6WVayPi9qmSmdWeki48i5AVE=
+github.com/eclipse/paho.golang v0.22.0/go.mod h1:9ZiYJ93iEfGRJri8tErNeStPKLXIGBHiqbHV74t5pqI=
 github.com/go-chi/chi/v5 v5.2.0 h1:Aj1EtB0qR2Rdo2dG4O94RIU35w2lvQSj6BRA4+qwFL0=
 github.com/go-chi/chi/v5 v5.2.0/go.mod h1:DslCQbL2OYiznFReuXYUmQ2hGd1aDpCnlMNITLSKoi8=
 github.com/go-chi/chi/v5 v5.2.1 h1:KOIHODQj58PmL80G2Eak4WdvUzjSJSm0vG72crDCqb8=
 github.com/go-chi/chi/v5 v5.2.1/go.mod h1:L2yAIGWB3H+phAw1NxKwWM+7eUH/lU8pOMm5hHcoops=
 github.com/godbus/dbus/v5 v5.0.4/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=
+github.com/google/go-cmp v0.5.9 h1:O2Tfq5qg4qc4AmwVlvv0oLiVAGB7enBSJ2x2DqQFi38=
+github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/gorilla/websocket v1.5.3 h1:saDtZ6Pbx/0u+bgYQ3q96pZgCzfhKXGPqt7kZ72aNNg=
 github.com/gorilla/websocket v1.5.3/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/kr/pretty v0.1.0 h1:L/CwN0zerZDmRFUapSPitk6f+Q3+0za1rQkzVuMiMFI=
@@ -33,6 +36,10 @@ github.com/urfave/cli/v3 v3.0.0-beta1 h1:6DTaaUarcM0wX7qj5Hcvs+5Dm3dyUTBbEwIWAjc
 github.com/urfave/cli/v3 v3.0.0-beta1/go.mod h1:FnIeEMYu+ko8zP1F9Ypr3xkZMIDqW3DR92yUtY39q1Y=
 go.uber.org/automaxprocs v1.6.0 h1:O3y2/QNTOdbF+e/dpXNNW7Rx2hZ4sTIPyybbxyNqTUs=
 go.uber.org/automaxprocs v1.6.0/go.mod h1:ifeIMSnPZuznNm6jmdzmU3/bfk01Fe2fotchwEFJ8r8=
+go.uber.org/goleak v1.2.1 h1:NBol2c7O1ZokfZ0LEU9K6Whx/KnwvepVetCUhtKja4A=
+go.uber.org/goleak v1.2.1/go.mod h1:qlT2yGI9QafXHhZZLxlSuNsMw3FFLxBr+tBRlmO1xH4=
+golang.org/x/net v0.27.0 h1:5K3Njcw06/l2y9vpGCSdcxWOYHOUk3dVNGDXN+FvAys=
+golang.org/x/net v0.27.0/go.mod h1:dDi0PyhWNoiUOrAS8uXv/vnScO4wnHQO4mj9fn/RytE=
 golang.org/x/sync v0.10.0 h1:3NQrjDixjgGwUOCaF8w2+VYHv0Ve/vGYSbdkTa98gmQ=
 golang.org/x/sync v0.10.0/go.mod h1:Czt+wKu1gCyEFDUtn0jG5QVvpJ6rzVqr5aXyt9drQfk=
 golang.org/x/sync v0.11.0 h1:GGz8+XQP4FvTTrjZPzNKTMFtSXH80RAzG+5ghFPgK9w=

--- a/pkg/mqtt/mqtt_broadcast.go
+++ b/pkg/mqtt/mqtt_broadcast.go
@@ -1,0 +1,133 @@
+package mqtt
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+	"strings"
+
+	"encoding/json"
+
+	"github.com/eclipse/paho.golang/autopaho"
+	"github.com/eclipse/paho.golang/paho"
+	"github.com/kalbasit/signal-api-receiver/pkg/receiver"
+	"github.com/rs/zerolog"
+)
+
+type config struct {
+	Qos         int64
+	TopicPrefix string
+}
+
+type newMessageNotifier struct {
+	Logger  zerolog.Logger
+	Config  config
+	Topic   string
+	Manager *autopaho.ConnectionManager
+	ctx     context.Context
+}
+
+func Init(
+	ctx context.Context,
+	server string,
+	clientId string,
+	user string,
+	password string,
+	topicPrefix string,
+	qos int64,
+) error {
+	logger := *zerolog.Ctx(ctx)
+
+	if !strings.HasPrefix(server, "mqtt://") {
+		server = strings.Join([]string{"mqtt://", server}, "")
+	}
+	serverUrl, err := url.Parse(server)
+
+	if err != nil {
+		return fmt.Errorf("error while parsing the mqtt server url %s: %w", server, err)
+	}
+
+	conn, err := autopaho.NewConnection(ctx, autopaho.ClientConfig{
+		ServerUrls:                    []*url.URL{serverUrl},
+		ConnectUsername:               user,
+		ConnectPassword:               []byte(password),
+		CleanStartOnInitialConnection: false,
+		SessionExpiryInterval:         60,
+		KeepAlive:                     20,
+		OnConnectionUp: func(cm *autopaho.ConnectionManager, connAck *paho.Connack) {
+			logger.Info().Msg("MQTT: connection successfully established.")
+		},
+		OnConnectError: func(err error) { fmt.Printf("error whilst attempting mqtt connection: %s\n", err) },
+		ClientConfig: paho.ClientConfig{
+			ClientID:      clientId,
+			OnClientError: func(err error) { fmt.Printf("mqtt client error: %s\n", err) },
+			OnServerDisconnect: func(d *paho.Disconnect) {
+				if d.Properties != nil {
+					fmt.Printf("mqtt server requested disconnect: %s\n", d.Properties.ReasonString)
+				} else {
+					fmt.Printf("mqtt server requested disconnect; reason code: %d\n", d.ReasonCode)
+				}
+			},
+		},
+	})
+
+	if err != nil {
+		return fmt.Errorf("error whilst attempting mqtt connection: %w", err)
+	}
+
+	if err = conn.AwaitConnection(ctx); err != nil {
+		return fmt.Errorf("mqtt error while waiting for connection: %w", err)
+	}
+
+	newMessageNotifier := newMessageNotifier{
+		Logger: logger,
+		Topic:  strings.Join([]string{strings.Trim(topicPrefix, "#/ "), "message"}, "/"),
+		Config: config{
+			Qos:         qos,
+			TopicPrefix: topicPrefix,
+		},
+		Manager: conn,
+		ctx:     ctx,
+	}
+
+	receiver.NewMessage.Register(newMessageNotifier)
+
+	return nil
+}
+
+type PublishPayload struct {
+	Message *receiver.Message `json:"content"`
+	Types   []string          `json:"types"`
+}
+
+func (m newMessageNotifier) broadcast(messagePayload receiver.NewMessagePayload) {
+	m.Logger.Debug().Msg("MQTT: Broadcast new message")
+
+	payloadFormat := byte(1)
+	payload, err := json.Marshal(PublishPayload{Message: &messagePayload.Message, Types: messagePayload.Message.MessageTypesStrings()})
+
+	if err != nil {
+		m.Logger.Err(fmt.Errorf("error while stringify message: %w", err))
+		return
+	}
+
+	_, err = m.Manager.Publish(m.ctx, &paho.Publish{
+		QoS:    byte(m.Config.Qos),
+		Topic:  m.Topic,
+		Retain: false,
+		Properties: &paho.PublishProperties{
+			PayloadFormat: &payloadFormat,
+			ContentType:   "application/json",
+		},
+		Payload: payload,
+	})
+
+	if err != nil {
+		m.Logger.Err(fmt.Errorf("error while publishing message: %w", err))
+		return
+	}
+}
+
+func (m newMessageNotifier) Handle(messagePayload receiver.NewMessagePayload) {
+	m.broadcast(messagePayload)
+}

--- a/pkg/receiver/client.go
+++ b/pkg/receiver/client.go
@@ -149,6 +149,10 @@ func (c *Client) recordMessage(msg []byte) {
 	c.messages = append(c.messages, m)
 	c.mu.Unlock()
 
+	NewMessage.Trigger(NewMessagePayload{
+		Message: m,
+	})
+
 	//nolint:zerologlint
 	if c.logger.Debug().Enabled() {
 		c.logger.

--- a/pkg/receiver/message.go
+++ b/pkg/receiver/message.go
@@ -202,3 +202,23 @@ func (m Message) MessageTypesStrings() []string {
 
 	return ss
 }
+
+var NewMessage newMessage
+
+type NewMessagePayload struct {
+	Message Message
+}
+
+type newMessage struct {
+	handlers []interface{ Handle(NewMessagePayload) }
+}
+
+func (u *newMessage) Register(handler interface{ Handle(NewMessagePayload) }) {
+	u.handlers = append(u.handlers, handler)
+}
+
+func (u newMessage) Trigger(payload NewMessagePayload) {
+	for _, handler := range u.handlers {
+		go handler.Handle(payload)
+	}
+}


### PR DESCRIPTION
### Description

With this feature, new messages are not only provided in the existing HTTP queue, but can also be broadcasted in a MQTT topic that can be configured as needed.

### Introduces following MQTT configuration parameters:

- server
- user
- password
- client-id
- topic-prefix
- qos

### Topic payload

```ts
type TPayload = {
  content: {    // extends the message struct
    account: {
      // [...]
    };
    envelope: {
      // [...]
    };
  };
  types: string[];
};
```

@kalbasit Please let me know your thoughts on that