### PR TITLE
fix: Auto Update VendorHash is failing to push commits

### DIFF
--- a/.github/workflows/auto-update-vendorhash.yaml
+++ b/.github/workflows/auto-update-vendorhash.yaml
@@ -11,6 +11,8 @@ jobs:
       - uses: actions/checkout@v4
         with:
           token: ${{ secrets.GHA_PAT_TOKEN }}
+          ref: ${{ github.event.pull_request.head.ref }}
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
       - uses: DeterminateSystems/nix-installer-action@v17
       - uses: DeterminateSystems/magic-nix-cache-action@v9
       - run: |


### PR DESCRIPTION
Clone the repository using the correct remote URL and the branch name, otherwise it's not possible to push changes back to it. This used to work as-is before so it must be recent changes on GitHub that broke this.