### PR TITLE
fix: response body of '/receive/pop' is empty

### DIFF
--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -100,9 +100,9 @@ func (s *Server) receivePop(w http.ResponseWriter, _ *http.Request) {
 	}
 
 	if msg == nil {
-		w.WriteHeader(http.StatusNoContent)
-
-		return
+		// To comply with the `application/json` Content-Type in header we need to avoid an empty body.
+		// Therefor an empty object is used as msg instead
+		msg = &receiver.Message{}
 	}
 
 	w.Header().Set(contentType, contentTypeJSON)

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -98,7 +98,15 @@ func TestServeHTTP(t *testing.T) {
 			resp, err := http.Get(hs.URL + "/receive/pop")
 			require.NoError(t, err)
 
-			assert.Equal(t, http.StatusNoContent, resp.StatusCode)
+			assert.Equal(t, http.StatusOK, resp.StatusCode)
+
+			body, err := io.ReadAll(resp.Body)
+			require.NoError(t, err)
+
+			var got receiver.Message
+			require.NoError(t, json.Unmarshal(body, &got))
+
+			assert.Equal(t, receiver.Message{}, got)
 		})
 
 		t.Run("one message in the queue", func(t *testing.T) {


### PR DESCRIPTION
To comply with the `application/json` Content-Type in header we need to avoid an empty body. Therefor an empty object is used as msg instead.

Fixes #152